### PR TITLE
customize gas simulator to return base + simulated gas amount

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1160,9 +1160,16 @@ func (app *InitiaApp) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.API
 	}
 }
 
+// Simulate customize gas simulation to add fee deduction gas amount.
+func (app *InitiaApp) Simulate(txBytes []byte) (sdk.GasInfo, *sdk.Result, error) {
+	gasInfo, result, err := app.BaseApp.Simulate(txBytes)
+	gasInfo.GasUsed += FeeDeductionGasAmount
+	return gasInfo, result, err
+}
+
 // RegisterTxService implements the Application.RegisterTxService method.
 func (app *InitiaApp) RegisterTxService(clientCtx client.Context) {
-	authtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.BaseApp.Simulate, app.interfaceRegistry)
+	authtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.Simulate, app.interfaceRegistry)
 }
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.

--- a/app/const.go
+++ b/app/const.go
@@ -5,6 +5,9 @@ import (
 )
 
 const (
+	// FeeDeductionGasAmount is a estimated gas amount of fee payment
+	FeeDeductionGasAmount = 180_000
+
 	// AccountAddressPrefix is the prefix of bech32 encoded address
 	AccountAddressPrefix = "init"
 


### PR DESCRIPTION
fee payment with move takes a huge gas than normal cosmos bank send, so we just add const base gas amount for fee simulation.