### PR TITLE
fix: return empty arrays when get 0 arguments

### DIFF
--- a/x/move/client/cli/utils.go
+++ b/x/move/client/cli/utils.go
@@ -295,6 +295,10 @@ func DivideUint256String(s string) (uint64, uint64, uint64, uint64, error) {
 }
 
 func parseArguments(s string) (tt []string, args []string) {
+	if len(s) == 0 {
+		return
+	}
+
 	cursor := 0
 
 	var t, a string


### PR DESCRIPTION
Problem
- return `[''], ['']` when give empty arguments

Solve
- if arguments's length is 0 return `[], []`