### PR TITLE
replace homePath with default if it's empty

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -419,6 +419,9 @@ func NewInitiaApp(
 		skipUpgradeHeights[int64(h)] = true
 	}
 	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
+	if homePath == "" {
+		homePath = DefaultNodeHome
+	}
 	app.UpgradeKeeper = upgradekeeper.NewKeeper(
 		skipUpgradeHeights,
 		runtime.NewKVStoreService(keys[upgradetypes.StoreKey]),


### PR DESCRIPTION
if we run initiad without `--home`, L421 returns empty string.
so i think replacing with DefaultNodeHome if homePath is empty will prevent upgradeKeeper's odd behavior(downloading binaries into cwd i guess).

if this pr approved, i'll make a pr for cosmos-sdk/simapp also :)