### PR TITLE
chore: upgrade slinky ref

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/skip-mev/block-sdk v0.0.0-20231213233341-deceeb0e993b
-	github.com/skip-mev/slinky v0.2.1
+	github.com/skip-mev/slinky v0.2.2
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -983,8 +983,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skip-mev/block-sdk v0.0.0-20231213233341-deceeb0e993b h1:p7treH8qfsqJa31MNCh/xWItMWS+kub3GSH2dYN+0uk=
 github.com/skip-mev/block-sdk v0.0.0-20231213233341-deceeb0e993b/go.mod h1:yvRRZgkinnjsvf6357Fg9Nbi8vRYIJWOLB+cwz3uCP8=
-github.com/skip-mev/slinky v0.2.1 h1:JFVzIueCXQfibMfJGf4nQ+4+r+Dhv8W6bFLJbH+HoRY=
-github.com/skip-mev/slinky v0.2.1/go.mod h1:HBzskXU/8d7cNthgmksHp+KZHQ7vZbGazfsnT2SqQhI=
+github.com/skip-mev/slinky v0.2.2 h1:LlJDfmr45l3G+3GJhNRyWS72+FKAWjQxDfhZkzOC0/w=
+github.com/skip-mev/slinky v0.2.2/go.mod h1:HBzskXU/8d7cNthgmksHp+KZHQ7vZbGazfsnT2SqQhI=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=


### PR DESCRIPTION
## In This PR
- I upgrade the `slinky` ref to [v0.2.1](https://github.com/skip-mev/slinky/releases/tag/v0.2.1)