### PR TITLE
fix: vm api query to return used gas

### DIFF
--- a/x/move/keeper/api.go
+++ b/x/move/keeper/api.go
@@ -125,8 +125,11 @@ func (api GoApi) Query(req vmtypes.QueryRequest, gasBalance uint64) ([]byte, uin
 	sdkCtx := sdk.UnwrapSDKContext(api.ctx).WithGasMeter(storetypes.NewGasMeter(gasBalance))
 
 	res, err := api.Keeper.HandleVMQuery(sdkCtx, &req)
-	gasUsed := sdkCtx.GasMeter().GasConsumed()
-	return res, gasUsed, err
+	if err != nil {
+		return nil, sdkCtx.GasMeter().GasConsumed(), err
+	}
+
+	return res, sdkCtx.GasMeter().GasConsumed(), err
 }
 
 // convert math.Int to little endian bytes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the `Query` method to use a normal gas meter with a maximum gas limit, enhancing gas consumption tracking. The method's return values now separately include gas consumption details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->