### PR TITLE
fix naming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21-alpine AS go-builder
 #ARG arch=x86_64
 
 # See https://github.com/initia-labs/movevm/releases
-ENV LIBINITIAVM_VERSION=v0.2.0
+ENV LIBMOVEVM_VERSION=v0.2.0
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
@@ -21,8 +21,8 @@ RUN git clone --depth 1 https://github.com/microsoft/mimalloc; cd mimalloc; mkdi
 ENV MIMALLOC_RESERVE_HUGE_OS_PAGES=4
 
 # See https://github.com/initia-labs/movevm/releases
-ADD https://github.com/initia-labs/movevm/releases/download/${LIBINITIAVM_VERSION}/libmovevm_muslc.aarch64.a /lib/libmovevm_muslc.aarch64.a
-ADD https://github.com/initia-labs/movevm/releases/download/${LIBINITIAVM_VERSION}/libmovevm_muslc.x86_64.a /lib/libmovevm_muslc.x86_64.a
+ADD https://github.com/initia-labs/movevm/releases/download/${LIBMOVEVM_VERSION}/libmovevm_muslc.aarch64.a /lib/libmovevm_muslc.aarch64.a
+ADD https://github.com/initia-labs/movevm/releases/download/${LIBMOVEVM_VERSION}/libmovevm_muslc.x86_64.a /lib/libmovevm_muslc.x86_64.a
 
 # Highly recommend to verify the version hash
 # RUN sha256sum /lib/libmovevm_muslc.aarch64.a | grep a5e63292ec67f5bdefab51b42c3fbc3fa307c6aefeb6b409d971f1df909c3927

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/cometbft/cometbft v0.38.5
 	github.com/cosmos/cosmos-db v1.0.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.4
-	github.com/cosmos/cosmos-sdk v0.50.3
+	github.com/cosmos/cosmos-sdk v0.50.4
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8 v8.0.1
@@ -38,7 +38,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-metrics v0.5.2
 	github.com/initia-labs/OPinit v0.2.0-beta.1
-	// we also need to update `LIBINITIAVM_VERSION` of images/private/Dockerfile#5
+	// we also need to update `LIBMOVEVM_VERSION` of images/private/Dockerfile#5
 	github.com/initia-labs/movevm v0.0.0-20240228123400-2951cc64c945
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1

--- a/images/README.md
+++ b/images/README.md
@@ -10,7 +10,7 @@ Build like:
 ``` bash
 docker build \
     -t initiad \
-    --build-arg LIBINITIAVM_VERSION=v1.0.0 \
+    --build-arg LIBMOVEVM_VERSION=v1.0.0 \
     --build-arg GITHUB_ACCESS_TOKEN=$PAT \
     -f images/private/Dockerfile \
     .

--- a/images/private/Dockerfile
+++ b/images/private/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21-alpine AS go-builder
 #ARG arch=x86_64
 
 # See https://github.com/initia-labs/movevm/releases
-ARG LIBINITIAVM_VERSION=v0.2.0
+ARG LIBMOVEVM_VERSION=v0.2.0
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
@@ -28,7 +28,7 @@ RUN git config --global url."https://${GITHUB_ACCESS_TOKEN}:x-oauth-basic@github
 ADD https://github.com/gruntwork-io/fetch/releases/download/v0.4.6/fetch_linux_amd64 /usr/bin/fetch
 RUN chmod +x /usr/bin/fetch
 ENV GITHUB_OAUTH_TOKEN=$GITHUB_ACCESS_TOKEN
-RUN fetch --repo="https://github.com/initia-labs/movevm" --tag="${LIBINITIAVM_VERSION}" --release-asset="libmovevm_muslc.*.a" /lib/
+RUN fetch --repo="https://github.com/initia-labs/movevm" --tag="${LIBMOVEVM_VERSION}" --release-asset="libmovevm_muslc.*.a" /lib/
 RUN cp /lib/libmovevm_muslc.`uname -m`.a /lib/libmovevm_muslc.a
 
 # force it to use static lib (from above) not standard libmovevm.so file

--- a/scripts/protoc-swagger-gen.sh
+++ b/scripts/protoc-swagger-gen.sh
@@ -19,15 +19,15 @@ ICQ_VERSION=$(cat ./go.mod | grep "$ICQ_URL/$IBC_V v" | sed -n -e "s/^.* //p" | 
 OPINIT_VERSION=$(cat ./go.mod | grep "$OPINIT_URL v" | sed -n -e "s/^.* //p")
 SLINKY_VERSION=$(cat ./go.mod | grep "$SLINKY_URL v" | sed -n -e "s/^.* //p")
 
-# mkdir -p ./third_party
-# cd third_party
-# git clone -b $COSMOS_SDK_VERSION https://$COSMOS_URL
-# git clone -b $IBC_VERSION https://$IBC_URL
-# git clone -b $OPINIT_VERSION https://$OPINIT_URL
-# git clone -b $SLINKY_VERSION https://$SLINKY_URL
-# git clone -b middleware/packet-forward-middleware/$PFM_VERSION https://$IBC_APP_URL ./PFM
-# git clone -b modules/async-icq/$ICQ_VERSION https://$IBC_APP_URL ./ICQ
-# cd ..
+mkdir -p ./third_party
+cd third_party
+git clone -b $COSMOS_SDK_VERSION https://$COSMOS_URL
+git clone -b $IBC_VERSION https://$IBC_URL
+git clone -b $OPINIT_VERSION https://$OPINIT_URL
+git clone -b $SLINKY_VERSION https://$SLINKY_URL
+git clone -b middleware/packet-forward-middleware/$PFM_VERSION https://$IBC_APP_URL ./PFM
+git clone -b modules/async-icq/$ICQ_VERSION https://$IBC_APP_URL ./ICQ
+cd ..
 
 # start generating
 mkdir -p ./tmp-swagger-gen

--- a/shared.Dockerfile
+++ b/shared.Dockerfile
@@ -11,7 +11,7 @@ COPY . /code/
 
 RUN LEDGER_ENABLED=false make build
 
-RUN cp /go/pkg/mod/github.com/initia\-labs/initiavm@v*/api/libmovevm.`uname -m`.so /lib/libmovevm.so
+RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libmovevm.`uname -m`.so /lib/libmovevm.so
 
 FROM ubuntu:20.04
 

--- a/x/move/keeper/contracts/Move.toml
+++ b/x/move/keeper/contracts/Move.toml
@@ -3,7 +3,7 @@ name = "test1"
 version = "0.0.0"
 
 [dependencies]
-InitiaStdlib = { local = "../../../../../initiavm/precompile/modules/initia_stdlib"  }
+InitiaStdlib = { local = "../../../../../movevm/precompile/modules/initia_stdlib"  }
 
 [addresses]
 initia_std = "0x1"


### PR DESCRIPTION
LIBINITIAVM => LIBMOVEVM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Dockerfiles and related scripts to incorporate the `libmovevm` library in the build process.
	- Updated README.md to reflect changes in the Docker build command for `LIBMOVEVM_VERSION`.
	- Improved setup of third-party dependencies in protoc-swagger-gen.sh script.
	- Updated path for copying a library file in shared.Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->