### PR TITLE
move hook bug

### DIFF
--- a/x/ibc-hooks/move-hooks/hooks.go
+++ b/x/ibc-hooks/move-hooks/hooks.go
@@ -8,6 +8,9 @@ import (
 
 	ibchooks "github.com/initia-labs/initia/x/ibc-hooks"
 	movekeeper "github.com/initia-labs/initia/x/move/keeper"
+	movetypes "github.com/initia-labs/initia/x/move/types"
+
+	vmtypes "github.com/initia-labs/movevm/types"
 )
 
 var (
@@ -65,10 +68,10 @@ func (h MoveHooks) OnTimeoutPacketOverride(im ibchooks.IBCMiddleware, ctx sdk.Co
 }
 
 func (h MoveHooks) checkACL(im ibchooks.IBCMiddleware, ctx sdk.Context, addrStr string) (bool, error) {
-	addr, err := h.ac.StringToBytes(addrStr)
+	vmAddr, err := vmtypes.NewAccountAddress(addrStr)
 	if err != nil {
 		return false, err
 	}
-
-	return im.HooksKeeper.GetAllowed(ctx, addr)
+	sdkAddr := movetypes.ConvertVMAddressToSDKAddress(vmAddr)
+	return im.HooksKeeper.GetAllowed(ctx, sdkAddr)
 }


### PR DESCRIPTION
when checking acl in move hooks, it should convert vm address to sdk address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new functionality for account address conversion and ACL checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->