### PR TITLE
add gov custom queries

### DIFF
--- a/x/gov/autocli.go
+++ b/x/gov/autocli.go
@@ -16,31 +16,6 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 			Service: govv1.Query_ServiceDesc.ServiceName,
 			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
 				{
-					RpcMethod: "Params",
-					Use:       "params",
-					Short:     "Query the parameters of the governance process",
-					Long:      "Query the parameters of the governance process. Specify specific param types (voting|tallying|deposit) to filter results.",
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
-						{ProtoField: "params_type", Optional: true},
-					},
-				},
-				{
-					RpcMethod: "Proposals",
-					Use:       "proposals",
-					Short:     "Query proposals with optional filters",
-					Example:   fmt.Sprintf("%[1]s query gov proposals --depositor cosmos1...\n%[1]s query gov proposals --voter cosmos1...\n%[1]s query gov proposals --proposal-status (PROPOSAL_STATUS_DEPOSIT_PERIOD|PROPOSAL_STATUS_VOTING_PERIOD|PROPOSAL_STATUS_PASSED|PROPOSAL_STATUS_REJECTED|PROPOSAL_STATUS_FAILED)", version.AppName),
-				},
-				{
-					RpcMethod: "Proposal",
-					Use:       "proposal [proposal-id]",
-					Alias:     []string{"proposer"},
-					Short:     "Query details of a single proposal",
-					Example:   fmt.Sprintf("%s query gov proposal 1", version.AppName),
-					PositionalArgs: []*autocliv1.PositionalArgDescriptor{
-						{ProtoField: "proposal_id"},
-					},
-				},
-				{
 					RpcMethod: "Vote",
 					Use:       "vote [proposal-id] [voter-addr]",
 					Short:     "Query details of a single vote",

--- a/x/gov/client/cli/query.go
+++ b/x/gov/client/cli/query.go
@@ -1,0 +1,275 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"cosmossdk.io/core/address"
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/version"
+
+	gcutils "github.com/cosmos/cosmos-sdk/x/gov/client/utils"
+	"github.com/cosmos/cosmos-sdk/x/gov/types"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	customtypes "github.com/initia-labs/initia/x/gov/types"
+)
+
+// Proposal flags
+const (
+	flagDepositor = "depositor"
+	flagVoter     = "voter"
+	flagStatus    = "status"
+)
+
+// GetQueryCmd returns the cli query commands for this module
+func GetQueryCmd(ac address.Codec) *cobra.Command {
+	// Group gov queries under a subcommand
+	govQueryCmd := &cobra.Command{
+		Use:                        types.ModuleName,
+		Short:                      "Querying commands for the governance module",
+		DisableFlagParsing:         true,
+		SuggestionsMinimumDistance: 2,
+		RunE:                       client.ValidateCmd,
+	}
+
+	govQueryCmd.AddCommand(
+		GetCmdQueryEmergencyProposals(),
+		GetCmdQueryProposal(),
+		GetCmdQueryProposals(ac),
+		GetCmdQueryParams(),
+	)
+
+	return govQueryCmd
+}
+
+// GetCmdQueryEmergencyProposals implements a query emergency proposals command. Command to Get
+// Proposals Information.
+func GetCmdQueryEmergencyProposals() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "emergency_proposals",
+		Short: "Query emergency proposals",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query for a all paginated emergencay proposals 
+$ %s query gov proposals --page=2 --limit=100
+`,
+				version.AppName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := customtypes.NewQueryClient(clientCtx)
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.EmergencyProposals(
+				cmd.Context(),
+				&customtypes.QueryEmergencyProposalsRequest{
+					Pagination: pageReq,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if len(res.GetProposals()) == 0 {
+				return fmt.Errorf("no proposals found")
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddPaginationFlagsToCmd(cmd, "proposals")
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryProposal implements the query proposal command.
+func GetCmdQueryProposal() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proposal [proposal-id]",
+		Args:  cobra.ExactArgs(1),
+		Short: "Query details of a single proposal",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query details for a proposal. You can find the
+proposal-id by running "%s query gov proposals".
+
+Example:
+$ %s query gov proposal 1
+`,
+				version.AppName, version.AppName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := customtypes.NewQueryClient(clientCtx)
+
+			// validate that the proposal id is a uint
+			proposalID, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("proposal-id %s not a valid uint, please input a valid proposal-id", args[0])
+			}
+
+			// Query the proposal
+			res, err := queryClient.Proposal(
+				cmd.Context(),
+				&customtypes.QueryProposalRequest{ProposalId: proposalID},
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res.Proposal)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryProposals implements a query proposals command. Command to Get
+// Proposals Information.
+func GetCmdQueryProposals(ac address.Codec) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "proposals",
+		Short: "Query proposals with optional filters",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query for a all paginated proposals that match optional filters:
+
+Example:
+$ %s query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ %s query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ %s query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Rejected)
+$ %s query gov proposals --page=2 --limit=100
+`,
+				version.AppName, version.AppName, version.AppName, version.AppName,
+			),
+		),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bechDepositorAddr, _ := cmd.Flags().GetString(flagDepositor)
+			bechVoterAddr, _ := cmd.Flags().GetString(flagVoter)
+			strProposalStatus, _ := cmd.Flags().GetString(flagStatus)
+
+			var proposalStatus v1.ProposalStatus
+
+			if len(bechDepositorAddr) != 0 {
+				_, err := ac.StringToBytes(bechDepositorAddr)
+				if err != nil {
+					return err
+				}
+			}
+
+			if len(bechVoterAddr) != 0 {
+				_, err := ac.StringToBytes(bechVoterAddr)
+				if err != nil {
+					return err
+				}
+			}
+
+			if len(strProposalStatus) != 0 {
+				proposalStatus1, err := customtypes.ProposalStatusFromString(gcutils.NormalizeProposalStatus(strProposalStatus))
+				proposalStatus = proposalStatus1
+				if err != nil {
+					return err
+				}
+			}
+
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := customtypes.NewQueryClient(clientCtx)
+
+			pageReq, err := client.ReadPageRequest(cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			res, err := queryClient.Proposals(
+				cmd.Context(),
+				&customtypes.QueryProposalsRequest{
+					ProposalStatus: proposalStatus,
+					Voter:          bechVoterAddr,
+					Depositor:      bechDepositorAddr,
+					Pagination:     pageReq,
+				},
+			)
+			if err != nil {
+				return err
+			}
+
+			if len(res.GetProposals()) == 0 {
+				return fmt.Errorf("no proposals found")
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	cmd.Flags().String(flagDepositor, "", "(optional) filter by proposals deposited on by depositor")
+	cmd.Flags().String(flagVoter, "", "(optional) filter by proposals voted on by voted")
+	cmd.Flags().String(flagStatus, "", "(optional) filter proposals by proposal status, status: deposit_period/voting_period/passed/rejected")
+	flags.AddPaginationFlagsToCmd(cmd, "proposals")
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// GetCmdQueryParams implements the query params command.
+//
+//nolint:staticcheck // this function contains deprecated commands that we need.
+func GetCmdQueryParams() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "params",
+		Short: "Query the parameters of the governance process",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Query the all the parameters for the governance process.
+
+Example:
+$ %s query gov params
+`,
+				version.AppName,
+			),
+		),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := customtypes.NewQueryClient(clientCtx)
+
+			// Query store for all 3 params
+			ctx := cmd.Context()
+
+			res, err := queryClient.Params(
+				ctx,
+				&customtypes.QueryParamsRequest{},
+			)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}

--- a/x/gov/module.go
+++ b/x/gov/module.go
@@ -35,6 +35,8 @@ import (
 
 	"github.com/initia-labs/initia/x/gov/keeper"
 	customtypes "github.com/initia-labs/initia/x/gov/types"
+
+	customcli "github.com/initia-labs/initia/x/gov/client/cli"
 )
 
 const ConsensusVersion = 1
@@ -107,6 +109,11 @@ func (a AppModuleBasic) GetTxCmd() *cobra.Command {
 	legacyProposalCLIHandlers := getProposalCLIHandlers(a.legacyProposalHandlers)
 
 	return cli.NewTxCmd(legacyProposalCLIHandlers)
+}
+
+// GetQueryCmd returns no root query command for the staking module.
+func (b AppModuleBasic) GetQueryCmd() *cobra.Command {
+	return customcli.GetQueryCmd(b.cdc.InterfaceRegistry().SigningContext().AddressCodec())
 }
 
 func getProposalCLIHandlers(handlers []govclient.ProposalHandler) []*cobra.Command {


### PR DESCRIPTION
Current gov autocli generates queries of cosmos gov module. So, we cannot check emergency parameters from current querier. We need to add Initia custom gov cli queries: proposals, proposal, emergency_proposal, params. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added CLI commands for querying governance-related information.
    - Introduced a root query command for the staking module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->