### PR TITLE
bump: movevm to fix cache issue and compiler issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21-alpine AS go-builder
 #ARG arch=x86_64
 
 # See https://github.com/initia-labs/movevm/releases
-ENV LIBMOVEVM_VERSION=v0.2.1
+ENV LIBMOVEVM_VERSION=v0.2.2
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
@@ -23,15 +23,20 @@ ENV MIMALLOC_RESERVE_HUGE_OS_PAGES=4
 # See https://github.com/initia-labs/movevm/releases
 ADD https://github.com/initia-labs/movevm/releases/download/${LIBMOVEVM_VERSION}/libmovevm_muslc.aarch64.a /lib/libmovevm_muslc.aarch64.a
 ADD https://github.com/initia-labs/movevm/releases/download/${LIBMOVEVM_VERSION}/libmovevm_muslc.x86_64.a /lib/libmovevm_muslc.x86_64.a
+ADD https://github.com/initia-labs/movevm/releases/download/${LIBMOVEVM_VERSION}/libcompiler_muslc.aarch64.a /lib/libcompiler_muslc.aarch64.a
+ADD https://github.com/initia-labs/movevm/releases/download/${LIBMOVEVM_VERSION}/libcompiler_muslc.x86_64.a /lib/libcompiler_muslc.x86_64.a
 
 # Highly recommend to verify the version hash
 # RUN sha256sum /lib/libmovevm_muslc.aarch64.a | grep a5e63292ec67f5bdefab51b42c3fbc3fa307c6aefeb6b409d971f1df909c3927
 # RUN sha256sum /lib/libmovevm_muslc.x86_64.a | grep 762307147bf8f550bd5324b7f7c4f17ee20805ff93dc06cc073ffbd909438320
+# RUN sha256sum /lib/libcompiler_muslc.aarch64.a | grep a5e63292ec67f5bdefab51b42c3fbc3fa307c6aefeb6b409d971f1df909c3927
+# RUN sha256sum /lib/libcompiler_muslc.x86_64.a | grep 762307147bf8f550bd5324b7f7c4f17ee20805ff93dc06cc073ffbd909438320
 
 # Copy the library you want to the final location that will be found by the linker flag `-linitia_muslc`
 RUN cp /lib/libmovevm_muslc.`uname -m`.a /lib/libmovevm_muslc.a
+RUN cp /lib/libcompiler_muslc.`uname -m`.a /lib/libcompiler_muslc.a
 
-# force it to use static lib (from above) not standard libmovevm.so file
+# force it to use static lib (from above) not standard libmovevm.so and libcompiler.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LDFLAGS="-linkmode=external -extldflags \"-L/code/mimalloc/build -lmimalloc -Wl,-z,muldefs -static\"" make build
 
 FROM alpine:3.15.4

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,7 @@ build-linux-with-shared-library:
 	docker create --name temp initia/initiad-shared:latest
 	docker cp temp:/usr/local/bin/initiad $(BUILDDIR)/
 	docker cp temp:/lib/libmovevm.so $(BUILDDIR)/
+	docker cp temp:/lib/libcompiler.so $(BUILDDIR)/
 	docker rm temp
 
 install: go.sum 

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/hashicorp/go-metrics v0.5.2
 	github.com/initia-labs/OPinit v0.2.1
 	// we also need to update `LIBMOVEVM_VERSION` of images/private/Dockerfile#5
-	github.com/initia-labs/movevm v0.2.1
+	github.com/initia-labs/movevm v0.2.2
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,8 @@ github.com/initia-labs/cosmos-sdk v0.0.0-20240313050640-ff14560eeb21 h1:AwqnO5IR
 github.com/initia-labs/cosmos-sdk v0.0.0-20240313050640-ff14560eeb21/go.mod h1:oV/k6GJgXV9QPoM2fsYDPPsyPBgQbdotv532O6Mz1OQ=
 github.com/initia-labs/iavl v0.0.0-20240208034922-5d81c449d4c0 h1:GQ7/UD5mB6q104roqZK5jxb6ff9sBk0/uwFxgERQIaU=
 github.com/initia-labs/iavl v0.0.0-20240208034922-5d81c449d4c0/go.mod h1:CmTGqMnRnucjxbjduneZXT+0vPgNElYvdefjX2q9tYc=
-github.com/initia-labs/movevm v0.2.1 h1:r+8kBQPT9IhgcLzG9bbLaPY1an89ePd4NcaVSRieatw=
-github.com/initia-labs/movevm v0.2.1/go.mod h1:1EyJ06+Hn43MfaXZ+30a2gmhS5zjqiFF8oSF5CHai28=
+github.com/initia-labs/movevm v0.2.2 h1:ubUq8D5cLi2nWJiHWCcMG4EK4N0qMeYyfDeXQRdhbeA=
+github.com/initia-labs/movevm v0.2.2/go.mod h1:1EyJ06+Hn43MfaXZ+30a2gmhS5zjqiFF8oSF5CHai28=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/images/private/Dockerfile
+++ b/images/private/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.21-alpine AS go-builder
 #ARG arch=x86_64
 
 # See https://github.com/initia-labs/movevm/releases
-ARG LIBMOVEVM_VERSION=v0.2.1
+ARG LIBMOVEVM_VERSION=v0.2.2
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
@@ -29,9 +29,11 @@ ADD https://github.com/gruntwork-io/fetch/releases/download/v0.4.6/fetch_linux_a
 RUN chmod +x /usr/bin/fetch
 ENV GITHUB_OAUTH_TOKEN=$GITHUB_ACCESS_TOKEN
 RUN fetch --repo="https://github.com/initia-labs/movevm" --tag="${LIBMOVEVM_VERSION}" --release-asset="libmovevm_muslc.*.a" /lib/
+RUN fetch --repo="https://github.com/initia-labs/movevm" --tag="${LIBMOVEVM_VERSION}" --release-asset="libcompiler_muslc.*.a" /lib/
 RUN cp /lib/libmovevm_muslc.`uname -m`.a /lib/libmovevm_muslc.a
+RUN cp /lib/libcompiler_muslc.`uname -m`.a /lib/libcompiler_muslc.a
 
-# force it to use static lib (from above) not standard libmovevm.so file
+# force it to use static lib (from above) not standard libmovevm.so and libcompiler.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LDFLAGS="-linkmode=external -extldflags \"-L/code/mimalloc/build -lmimalloc -Wl,-z,muldefs -static\"" make build
 
 FROM alpine:3.15.4

--- a/shared.Dockerfile
+++ b/shared.Dockerfile
@@ -12,6 +12,7 @@ COPY . /code/
 RUN LEDGER_ENABLED=false make build
 
 RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libmovevm.`uname -m`.so /lib/libmovevm.so
+RUN cp /go/pkg/mod/github.com/initia\-labs/movevm@v*/api/libcompiler.`uname -m`.so /lib/libcompiler.so
 
 FROM ubuntu:20.04
 
@@ -19,6 +20,7 @@ WORKDIR /root
 
 COPY --from=go-builder /code/build/initiad /usr/local/bin/initiad
 COPY --from=go-builder /lib/libmovevm.so /lib/libmovevm.so
+COPY --from=go-builder /lib/libcompiler.so /lib/libcompiler.so
 
 # rest server
 EXPOSE 1317


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated `LIBMOVEVM_VERSION` to `v0.2.2` in Dockerfile
  - Added new `libcompiler_muslc` files for both architectures in Dockerfile
  - Included checksum verifications and copy commands for the new library in Dockerfile
  - Added copying of `libcompiler.so` to the build directory in Makefile
  - Enhanced Docker image in shared.Dockerfile with the new library for containerized environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->