### PR TITLE
fix: denom metadata query to return proper result for move coins

### DIFF
--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -173,13 +173,13 @@ func (k BaseKeeper) HasSupply(ctx context.Context, denom string) bool {
 // GetDenomMetaData retrieves the denomination metadata. returns the metadata and true if the denom exists,
 // false otherwise.
 func (k BaseKeeper) GetDenomMetaData(ctx context.Context, denom string) (types.Metadata, bool) {
-	m, err := k.MoveViewKeeper.DenomMetadata.Get(ctx, denom)
+	m, err := k.MoveViewKeeper.GetDenomMetaData(ctx, denom)
 	return m, err == nil
 }
 
 // HasDenomMetaData checks if the denomination metadata exists in store.
 func (k BaseKeeper) HasDenomMetaData(ctx context.Context, denom string) bool {
-	has, err := k.MoveViewKeeper.DenomMetadata.Has(ctx, denom)
+	has, err := k.MoveViewKeeper.HasDenomMetaData(ctx, denom)
 	return has && err == nil
 }
 

--- a/x/bank/keeper/view.go
+++ b/x/bank/keeper/view.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/collections"
@@ -61,6 +62,30 @@ func NewMoveViewKeeper(
 func (k MoveViewKeeper) Logger(ctx context.Context) log.Logger {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	return sdkCtx.Logger().With("module", "x/"+types.ModuleName)
+}
+
+// GetDenomMetaData returns the metadata of a specific denomination.
+func (k MoveViewKeeper) GetDenomMetaData(ctx context.Context, denom string) (types.Metadata, error) {
+	metadata, err := k.DenomMetadata.Get(ctx, denom)
+	if err != nil && errors.Is(err, collections.ErrNotFound) {
+		return k.mk.GetMetadata(ctx, denom)
+	} else if err != nil {
+		return types.Metadata{}, err
+	}
+
+	return metadata, nil
+}
+
+// HasDenomMetaData returns whether or not the metadata for a denomination exists.
+func (k MoveViewKeeper) HasDenomMetaData(ctx context.Context, denom string) (bool, error) {
+	found, err := k.DenomMetadata.Has(ctx, denom)
+	if err != nil {
+		return false, err
+	} else if !found {
+		return k.mk.HasMetadata(ctx, denom)
+	}
+
+	return found, nil
 }
 
 // HasBalance returns whether or not an account has at least amt balance.

--- a/x/bank/types/expected_keeper.go
+++ b/x/bank/types/expected_keeper.go
@@ -29,4 +29,5 @@ type MoveBankKeeper interface {
 
 	// fungible asset
 	GetMetadata(ctx context.Context, denom string) (cosmosbanktypes.Metadata, error)
+	HasMetadata(ctx context.Context, denom string) (bool, error)
 }

--- a/x/move/keeper/fungible_asset.go
+++ b/x/move/keeper/fungible_asset.go
@@ -69,6 +69,24 @@ func (k MoveBankKeeper) Symbol(ctx context.Context, metadata vmtypes.AccountAddr
 	}
 }
 
+// HasMetadata checks if the metadata for a fungible asset exists.
+func (k MoveBankKeeper) HasMetadata(
+	ctx context.Context,
+	denom string,
+) (bool, error) {
+	metadata, err := types.MetadataAddressFromDenom(denom)
+	if err != nil {
+		return false, err
+	}
+
+	return k.HasResource(ctx, metadata, vmtypes.StructTag{
+		Address:  vmtypes.StdAddress,
+		Module:   types.MoveModuleNameFungibleAsset,
+		Name:     types.ResourceNameMetadata,
+		TypeArgs: []vmtypes.TypeTag{},
+	})
+}
+
 // GetMetadata interprets move fungible asset metadata
 // to cosmos metadata.
 func (k MoveBankKeeper) GetMetadata(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - Updated denomination metadata retrieval and existence checks in `keeper.go` and `view.go` files for consistency and clarity.
    - Modified method names and calls to align with changes in `MoveViewKeeper` struct.
- **New Features**
    - Added `HasMetadata` method to `MoveBankKeeper` interface in `expected_keeper.go` and `fungible_asset.go` files for checking metadata existence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->