### PR TITLE
fix: use correct address codec for distribution tx cmd

### DIFF
--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -84,7 +84,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx sdkclient.Context, mux
 
 // GetTxCmd returns the root tx command for the distribution module.
 func (b AppModuleBasic) GetTxCmd() *cobra.Command {
-	return cli.NewTxCmd(b.cdc.InterfaceRegistry().SigningContext().AddressCodec(), b.cdc.InterfaceRegistry().SigningContext().ValidatorAddressCodec())
+	return cli.NewTxCmd(b.cdc.InterfaceRegistry().SigningContext().ValidatorAddressCodec(), b.cdc.InterfaceRegistry().SigningContext().AddressCodec())
 }
 
 // RegisterInterfaces implements InterfaceModule


### PR DESCRIPTION
Use the correct address codec for x/distribution tx cmd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Modified the `GetTxCmd` function in the distribution module to change the order of parameters for `cli.NewTxCmd`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->