### PR TITLE
feat: change voting power calculation to use only locked init balance

### DIFF
--- a/x/move/keeper/voting_power_test.go
+++ b/x/move/keeper/voting_power_test.go
@@ -44,6 +44,7 @@ func Test_GetVotingPowerWeights(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, sdk.NewDecCoins(
 		sdk.NewDecCoin(bondDenom, math.NewInt(1)),
-		sdk.NewDecCoinFromDec(denomLP, math.LegacyNewDecWithPrec(5, 1))),
+		// only locked base coin amount is considered
+		sdk.NewDecCoinFromDec(denomLP, math.LegacyNewDecWithPrec(4, 1))),
 		votingPowerWeights)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved voting power weight calculation by considering only locked base balance and adjusting weight calculations for denomLP coin amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->