### PR TITLE
bump movevm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22-alpine AS go-builder
+FROM golang:1.22-alpine3.19 AS go-builder
 #ARG arch=x86_64
 
 # See https://github.com/initia-labs/movevm/releases
-ENV LIBMOVEVM_VERSION=v0.2.4
+ENV LIBMOVEVM_VERSION=v0.2.5
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
@@ -39,7 +39,7 @@ RUN cp /lib/libcompiler_muslc.`uname -m`.a /lib/libcompiler_muslc.a
 # force it to use static lib (from above) not standard libmovevm.so and libcompiler.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LDFLAGS="-linkmode=external -extldflags \"-L/code/mimalloc/build -lmimalloc -Wl,-z,muldefs -static\"" make build
 
-FROM alpine:3.15.4
+FROM alpine:3.19
 
 RUN addgroup initia \
     && adduser -G initia -D -h /initia initia

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/hashicorp/go-metrics v0.5.2
 	github.com/initia-labs/OPinit v0.2.2
 	// we also need to update `LIBMOVEVM_VERSION` of images/private/Dockerfile#5
-	github.com/initia-labs/movevm v0.2.4
+	github.com/initia-labs/movevm v0.2.5
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,8 @@ github.com/initia-labs/cosmos-sdk v0.0.0-20240313050640-ff14560eeb21 h1:AwqnO5IR
 github.com/initia-labs/cosmos-sdk v0.0.0-20240313050640-ff14560eeb21/go.mod h1:oV/k6GJgXV9QPoM2fsYDPPsyPBgQbdotv532O6Mz1OQ=
 github.com/initia-labs/iavl v0.0.0-20240208034922-5d81c449d4c0 h1:GQ7/UD5mB6q104roqZK5jxb6ff9sBk0/uwFxgERQIaU=
 github.com/initia-labs/iavl v0.0.0-20240208034922-5d81c449d4c0/go.mod h1:CmTGqMnRnucjxbjduneZXT+0vPgNElYvdefjX2q9tYc=
-github.com/initia-labs/movevm v0.2.4 h1:Jc4Ak8zYOXNKMQW1wmDwBhfTdLStrn6z+QXnwyJEO5I=
-github.com/initia-labs/movevm v0.2.4/go.mod h1:6MxR4GP5zH3JUc1IMgfqAe1e483mZVS7fshPknZPJ30=
+github.com/initia-labs/movevm v0.2.5 h1:H2U+I/6X8Ue/MqixHuqOorTKEa8+E1qzLiVXicsW648=
+github.com/initia-labs/movevm v0.2.5/go.mod h1:6MxR4GP5zH3JUc1IMgfqAe1e483mZVS7fshPknZPJ30=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
 github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/images/private/Dockerfile
+++ b/images/private/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.22-alpine AS go-builder
+FROM golang:1.22-alpine3.19 AS go-builder
 #ARG arch=x86_64
 
 # See https://github.com/initia-labs/movevm/releases
-ARG LIBMOVEVM_VERSION=v0.2.4
+ARG LIBMOVEVM_VERSION=v0.2.5
 
 # this comes from standard alpine nightly file
 #  https://github.com/rust-lang/docker-rust-nightly/blob/master/alpine3.12/Dockerfile
@@ -36,7 +36,7 @@ RUN cp /lib/libcompiler_muslc.`uname -m`.a /lib/libcompiler_muslc.a
 # force it to use static lib (from above) not standard libmovevm.so and libcompiler.so file
 RUN LEDGER_ENABLED=false BUILD_TAGS=muslc LDFLAGS="-linkmode=external -extldflags \"-L/code/mimalloc/build -lmimalloc -Wl,-z,muldefs -static\"" make build
 
-FROM alpine:3.15.4
+FROM alpine:3.19
 
 RUN addgroup initia \
     && adduser -G initia -D -h /initia initia


### PR DESCRIPTION
fix cgo definitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated base image to `golang:1.22-alpine3.19` and `alpine:3.19`.
	- Updated `LIBMOVEVM_VERSION` from `v0.2.4` to `v0.2.5`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->