### PR TITLE
fix: api to return proper timestamp

### DIFF
--- a/x/move/keeper/api.go
+++ b/x/move/keeper/api.go
@@ -97,7 +97,7 @@ func (api GoApi) UnbondTimestamp() uint64 {
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(api.ctx)
-	return uint64(sdkCtx.BlockTime().Unix()) + uint64(unbondingTime)
+	return uint64(sdkCtx.BlockTime().Unix()) + uint64(unbondingTime.Seconds())
 }
 
 func (api GoApi) GetPrice(pairId string) ([]byte, uint64, uint64, error) {

--- a/x/move/keeper/api_test.go
+++ b/x/move/keeper/api_test.go
@@ -170,7 +170,7 @@ func Test_UnbondTimestamp(t *testing.T) {
 	stakingParams, err := input.StakingKeeper.GetParams(ctx)
 	require.NoError(t, err)
 
-	stakingParams.UnbondingTime = time.Duration(60 * 60 * 24 * 7)
+	stakingParams.UnbondingTime = time.Second * 60 * 60 * 24 * 7
 	input.StakingKeeper.SetParams(ctx, stakingParams)
 
 	now := time.Now()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Moved `UnbondingTime` functionality to use `time.Duration` type for `stakingParams`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->