### PR TITLE
fix: burn feature to send community funds once not multiple times

### DIFF
--- a/x/move/keeper/bank.go
+++ b/x/move/keeper/bank.go
@@ -396,7 +396,7 @@ func (k MoveBankKeeper) BurnCoins(
 
 	// fund community pool with the coins that are not generated from 0x1
 	if !communityPoolFunds.IsZero() {
-		if err := k.communityPoolKeeper.FundCommunityPool(ctx, coins, accAddr); err != nil {
+		if err := k.communityPoolKeeper.FundCommunityPool(ctx, communityPoolFunds, accAddr); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Updated logic in the `BurnCoins` function to accumulate coins for the community pool and fund it at the end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->