### PR TITLE
fix: continue searching for txs after finding one that exceeds the max bytes / gas limit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -231,6 +231,10 @@ func init() {
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+AppName)
 }
 
+const (
+	maxDefaultLaneSize = 2000
+)
+
 // InitiaApp extends an ABCI application, but with most of its parameters exported.
 // They are exported for convenience in creating helper functions, as object
 // capabilities aren't needed for testing.
@@ -1032,7 +1036,7 @@ func NewInitiaApp(
 		TxEncoder:       app.txConfig.TxEncoder(),
 		TxDecoder:       app.txConfig.TxDecoder(),
 		MaxBlockSpace:   math.LegacyMustNewDecFromStr("0.6"),
-		MaxTxs:          1000,
+		MaxTxs:          2000,
 		SignerExtractor: signerExtractor,
 	})
 

--- a/app/lanes/proposals.go
+++ b/app/lanes/proposals.go
@@ -83,7 +83,7 @@ func (h *DefaultProposalHandler) PrepareLaneHandler() blockbase.PrepareLaneHandl
 				)
 
 				// TODO: Determine if there is any trade off with breaking or continuing here.
-				break
+				continue
 			}
 
 			// If the gas limit of the transaction is too large, we break and do not attempt to include more txs.
@@ -97,7 +97,7 @@ func (h *DefaultProposalHandler) PrepareLaneHandler() blockbase.PrepareLaneHandl
 					"tx_hash", txInfo.Hash,
 				)
 
-				break
+				continue
 			}
 
 			// Verify the transaction.

--- a/app/lanes/proposals.go
+++ b/app/lanes/proposals.go
@@ -86,7 +86,6 @@ func (h *DefaultProposalHandler) PrepareLaneHandler() blockbase.PrepareLaneHandl
 					txsToRemove = append(txsToRemove, tx)
 				}
 
-				// TODO: Determine if there is any trade off with breaking or continuing here.
 				continue
 			}
 

--- a/app/lanes/proposals.go
+++ b/app/lanes/proposals.go
@@ -82,6 +82,10 @@ func (h *DefaultProposalHandler) PrepareLaneHandler() blockbase.PrepareLaneHandl
 					"tx_hash", txInfo.Hash,
 				)
 
+				if txInfo.Size > limit.MaxTxBytes {
+					txsToRemove = append(txsToRemove, tx)
+				}
+
 				// TODO: Determine if there is any trade off with breaking or continuing here.
 				continue
 			}
@@ -96,6 +100,10 @@ func (h *DefaultProposalHandler) PrepareLaneHandler() blockbase.PrepareLaneHandl
 					"max_gas", limit.MaxGasLimit,
 					"tx_hash", txInfo.Hash,
 				)
+
+				if txInfo.GasLimit > limit.MaxGasLimit {
+					txsToRemove = append(txsToRemove, tx)
+				}
 
 				continue
 			}


### PR DESCRIPTION
## In This PR
- We change the default lane prepare logic for default / free lanes to continue it's search for txs even if it finds a transaction that exceeds the gas / bytes limit for the block