### PR TITLE
chore: downgrade log-level for noisy but not critical logs and fix comment

### DIFF
--- a/app/lanes/proposals.go
+++ b/app/lanes/proposals.go
@@ -71,9 +71,9 @@ func (h *DefaultProposalHandler) PrepareLaneHandler() blockbase.PrepareLaneHandl
 				continue
 			}
 
-			// If the transaction is too large, we break and do not attempt to include more txs.
+			// If the transaction is too large, we skip it.
 			if updatedSize := totalSize + txInfo.Size; updatedSize > limit.MaxTxBytes {
-				h.lane.Logger().Info(
+				h.lane.Logger().Debug(
 					"failed to select tx for lane; tx bytes above the maximum allowed",
 					"lane", h.lane.Name(),
 					"tx_size", txInfo.Size,
@@ -89,9 +89,9 @@ func (h *DefaultProposalHandler) PrepareLaneHandler() blockbase.PrepareLaneHandl
 				continue
 			}
 
-			// If the gas limit of the transaction is too large, we break and do not attempt to include more txs.
+			// If the gas limit of the transaction is too large, we skip it.
 			if updatedGas := totalGas + txInfo.GasLimit; updatedGas > limit.MaxGasLimit {
-				h.lane.Logger().Info(
+				h.lane.Logger().Debug(
 					"failed to select tx for lane; gas limit above the maximum allowed",
 					"lane", h.lane.Name(),
 					"tx_gas", txInfo.GasLimit,


### PR DESCRIPTION
**related issue:** https://github.com/initia-labs/initia/issues/180

**downgrade log-level:**
I downgraded the log level because the log of the change made in this commit, were too numerous and not critical.

Tx selection algorithm during preparing lane is greedy algorithm meaning it iterates every transaction. If mempool has bunch of transactions, and block is almost reached its limit then log can be generated for rest of txs in a mempool.

**fix comment:**
Current tx selection algorithm is greedy algorithm, it does not break during iteration.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
initia user experience or initia developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of initia, if possible.
-->

<!--
Initia has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
