### PR TITLE
fix: use AccountNumberDecorator to avoid account number collision

### DIFF
--- a/app/ante/account_number.go
+++ b/app/ante/account_number.go
@@ -1,0 +1,48 @@
+package ante
+
+import (
+	storetypes "cosmossdk.io/store/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	cosmosante "github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+)
+
+// AccountNumberDecorator is a custom ante handler that increments the account number depending on
+// the execution mode (Simulate, CheckTx, Finalize).
+//
+// This is to avoid account number conflicts when running concurrent Simulate, CheckTx, and Finalize.
+type AccountNumberDecorator struct {
+	ak cosmosante.AccountKeeper
+}
+
+// NewAccountNumberDecorator creates a new instance of AccountNumberDecorator.
+func NewAccountNumberDecorator(ak cosmosante.AccountKeeper) AccountNumberDecorator {
+	return AccountNumberDecorator{ak}
+}
+
+// AnteHandle is the AnteHandler implementation for AccountNumberDecorator.
+func (and AccountNumberDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if !ctx.IsCheckTx() && !ctx.IsReCheckTx() && !simulate {
+		return next(ctx, tx, simulate)
+	}
+
+	ak := and.ak.(*authkeeper.AccountKeeper)
+
+	gasFreeCtx := ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+	num, err := ak.AccountNumber.Peek(gasFreeCtx)
+	if err != nil {
+		return ctx, err
+	}
+
+	accountNumAddition := uint64(1_000_000)
+	if simulate {
+		accountNumAddition += 1_000_000
+	}
+
+	if err := ak.AccountNumber.Set(gasFreeCtx, num+accountNumAddition); err != nil {
+		return ctx, err
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -73,6 +73,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	anteDecorators := []sdk.AnteDecorator{
+		NewAccountNumberDecorator(options.AccountKeeper),
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		moveante.NewGasPricesDecorator(),

--- a/go.mod
+++ b/go.mod
@@ -225,7 +225,6 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
 	github.com/cometbft/cometbft => github.com/initia-labs/cometbft v0.0.0-20240621095332-4bd01a7a4586
-	github.com/cosmos/cosmos-sdk => github.com/initia-labs/cosmos-sdk v0.0.0-20240627065534-d2180fcfd501
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.1.4
 
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.

--- a/go.sum
+++ b/go.sum
@@ -362,6 +362,8 @@ github.com/cosmos/cosmos-db v1.0.2 h1:hwMjozuY1OlJs/uh6vddqnk9j7VamLv+0DBlbEXbAK
 github.com/cosmos/cosmos-db v1.0.2/go.mod h1:Z8IXcFJ9PqKK6BIsVOB3QXtkKoqUOp1vRvPT39kOXEA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5 h1:eNcayDLpip+zVLRLYafhzLvQlSmyab+RC5W7ZfmxJLA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.5/go.mod h1:hQGLpiIUloJBMdQMMWb/4wRApmI9hjHH05nefC0Ojec=
+github.com/cosmos/cosmos-sdk v0.50.7 h1:LsBGKxifENR/DN4E1RZaitsyL93HU44x0p8EnMHp4V4=
+github.com/cosmos/cosmos-sdk v0.50.7/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=
@@ -731,8 +733,6 @@ github.com/initia-labs/OPinit/api v0.3.0 h1:OY8ijwmgZLoYwtw9LI1mSY3VC8PY+gtxJFit
 github.com/initia-labs/OPinit/api v0.3.0/go.mod h1:Xy/Nt3ubXLQ4zKn0m7RuQOM1sj8TVdlNNyek21TGYR0=
 github.com/initia-labs/cometbft v0.0.0-20240621095332-4bd01a7a4586 h1:zFQKoiRpiYLrT+6CW5uXNVS/jAhusRJOX3tNBSPxzp8=
 github.com/initia-labs/cometbft v0.0.0-20240621095332-4bd01a7a4586/go.mod h1:xOoGZrtUT+A5izWfHSJgl0gYZUE7lu7Z2XIS1vWG/QQ=
-github.com/initia-labs/cosmos-sdk v0.0.0-20240627065534-d2180fcfd501 h1:OcLFeu3V9T156H4n6WzPNfKWjIUKdkC0P0EBA8zEWFE=
-github.com/initia-labs/cosmos-sdk v0.0.0-20240627065534-d2180fcfd501/go.mod h1:84xDDJEHttRT7NDGwBaUOLVOMN0JNE9x7NbsYIxXs1s=
 github.com/initia-labs/movevm v0.3.3 h1:xUH5VvjBSfJP4jg3axefmBlcdZ/7qfVYnUU09R4oN4g=
 github.com/initia-labs/movevm v0.3.3/go.mod h1:6MxR4GP5zH3JUc1IMgfqAe1e483mZVS7fshPknZPJ30=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=


### PR DESCRIPTION
This is temporal solution to avoid account number collision error, which is occurred due to async Simulate, Finalize, CheckTx.
- https://github.com/cosmos/cosmos-sdk/issues/20685

This update is only works at (re)checkTx and Simulate mode and update account number to cache store by adding 1_000_000 and 2_000_000 according to exec mode. This will make each mode run the ante and msgs over this updated account number.