### PR TITLE
Fix typos and improve phrasing in PR and README templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ I have...
   <!-- * `feat`: A new feature
   * `fix`: A bug fix
   * `docs`: Documentation only changes
-  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semicolons, etc)
   * `refactor`: A code change that neither fixes a bug nor adds a feature
   * `perf`: A code change that improves performance
   * `test`: Adding missing tests or correcting existing tests

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,8 @@ are the most critical to review. -->
 
 ## Author Checklist
 
-_All items are required. Please add a note to the item if the item is not applicable and
-please add links to any relevant follow up issues._
+_All items are required. Please add a note to the item if the item is not applicable, and
+please add links to any relevant follow-up issues._
 
 I have...
 

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,6 +1,6 @@
 # Maintaining Initia Proto Files
 
-All of the Initia proto files are defined here. This folder should
+All the Initia proto files are defined here. This folder should
 be synced regularly with buf.build/initia-labs/initia regularly by
 a maintainer by running `buf push` in this folder.
 


### PR DESCRIPTION
This pull request addresses typos and minor improvements in the phrasing within the PULL_REQUEST_TEMPLATE.md and README.md files.

**Changes made:**
- Corrected minor typos and improved phrasing in the PULL_REQUEST_TEMPLATE.md file.
- Replaced "All of the" with "All the" in README.md for conciseness and clarity.
