### PR TITLE
ci: Update dependency-review.yml to enhance license restrictions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           comment-summary-in-pr: always
           fail-on-severity: moderate
-          deny-licenses: GPL-1.0-or-later, LGPL-2.0-or-later
+          deny-licenses: GPL-1.0-or-later, GPL-2.0-or-later, GPL-3.0-or-later, LGPL-2.0-or-later, LGPL-2.1-or-later, LGPL-3.0-or-later
           retry-on-snapshot-warnings: true


### PR DESCRIPTION
# Description

This pull request updates the `dependency-review.yml` file in the CI workflows to modify the list of denied licenses for dependency reviews. Specifically, it expands the denied licenses to include `GPL-2.0-or-later`, `GPL-3.0-or-later`, `LGPL-2.1-or-later`, and `LGPL-3.0-or-later`. These changes ensure stricter compliance with license policies.

Closes: #XXXX

---

## Author Checklist

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title (`ci`)
- [ ] confirmed `!` in the type prefix if API or client breaking change (not applicable)
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification (not applicable)
- [x] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests (not applicable)
- [x] updated the relevant documentation or specification, including comments
- [x] confirmed all CI checks have passed

---

## Reviewers Checklist

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
