### PR TITLE
refactor: remove redundant -path argument before -prune

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -8,7 +8,7 @@ set -e
 echo "Generating gogo proto code"
 
 cd proto
-proto_dirs=$(find ./initia ./ibc -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+proto_dirs=$(find ./initia ./ibc -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
     # this regex checks if a proto file has its go_package set to cosmossdk.io/api/...


### PR DESCRIPTION
# Description

`-path` was unnecessarily used before `-prune`. Since `-prune` already prevents recursion in `./initia` and `./ibc`, the extra argument wasn’t needed.

Cleaned it up to simplify the command without changing behavior.

---

## Author Checklist


I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] confirmed all CI checks have passed

## Reviewers Checklist

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed all author checklist items have been addressed
- [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
