### PR TITLE
perf: Fix SignModeEIP191Handler Initialization

### DIFF
--- a/tx/eip191.go
+++ b/tx/eip191.go
@@ -23,7 +23,7 @@ func NewSignModeEIP191Handler(options aminojson.SignModeHandlerOptions) *SignMod
 	}
 }
 
-var _ signing.SignModeHandler = SignModeEIP191Handler{}
+var _ signing.SignModeHandler = &SignModeEIP191Handler{}
 
 // Mode implements signing.SignModeHandler.Mode.
 func (SignModeEIP191Handler) Mode() signingv1beta1.SignMode {


### PR DESCRIPTION
# Description

`SignModeEIP191Handler{}` was creating a value without a pointer, even though `SignModeEIP191Handler` contains `*aminojson.SignModeHandler`. This made it incomplete without a pointer. Updated it to ensure proper initialization.

---

## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed all author checklist items have been addressed
- [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
