### PR TITLE
fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Initia Layer 1 serves as an orchestration layer, facilitating coordination o
 
 Initia's product stack unifies the architecture, offering users a singular chain experience when interacting with thousands of interwoven rollups and reducing entry barriers:
 
-- [InitiaScan](https://scan.initia.tech/initiation-1): A multi-chain explorer with VM-specific tools and information.
+- [InitiaScan](https://scan.testnet.initia.xyz/initiation-2): A multi-chain explorer with VM-specific tools and information.
 - [Initia App](https://app.testnet.initia.xyz): A centralized platform for all things related to Initia.
 - [Initia Usernames](https://usernames.testnet.initia.xyz): A blockchain-wide on-chain identity system.
 - [Initia Wallet](https://chromewebstore.google.com/detail/initia-wallet/ffbceckpkpbcmgiaehlloocglmijnpmp): A dedicated wallet designed for navigating the expansive Initia ecosystem.
@@ -31,7 +31,7 @@ Initia's product stack unifies the architecture, offering users a singular chain
 
 Join the Initia community for questions and updates!
 
-- [Twitter](https://twitter.com/initiaFDN)
+- [Twitter](https://x.com/initia)
 - [Discord](https://discord.gg/initia)
 - [Medium](https://medium.com/@initiafdn)
   


### PR DESCRIPTION
Some links in README are outdated, Medium link is still broken. The links on the official website also needs to be fixed, by the way.