### PR TITLE
refactor(x/reward): remove SetModuleAccount from AccountKeeper interface

### DIFF
--- a/x/reward/types/expected_keeper.go
+++ b/x/reward/types/expected_keeper.go
@@ -12,8 +12,6 @@ type AccountKeeper interface {
 	AddressCodec() address.Codec
 	GetModuleAddress(name string) sdk.AccAddress
 
-	// TODO remove with genesis 2-phases refactor https://github.com/cosmos/cosmos-sdk/issues/2862
-	SetModuleAccount(context.Context, sdk.ModuleAccountI)
 	GetModuleAccount(ctx context.Context, moduleName string) sdk.ModuleAccountI
 }
 


### PR DESCRIPTION
This commit removes the SetModuleAccount method from the AccountKeeper interface in the reward module as indicated by the TODO comment. The method is not used in the reward module and was marked for removal after the genesis 2-phases refactor in Cosmos SDK (issue #2862).

This change simplifies the interface and removes unnecessary dependencies, making the code cleaner and more maintainable.

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
