### PR TITLE
refactor: use -n for better readability in condition checks

### DIFF
--- a/scripts/protoc-swagger-gen.sh
+++ b/scripts/protoc-swagger-gen.sh
@@ -43,7 +43,7 @@ proto_dirs=$(find \
 for dir in $proto_dirs; do
   # generate swagger files (filter query files)
   query_file=$(find "${dir}" -maxdepth 1 \( -name 'query.proto' -o -name 'service.proto' \))
-  if [[ ! -z "$query_file" ]]; then
+  if [[ -n "$query_file" ]]; then
     buf generate --template buf.gen.swagger.yaml $query_file
   fi
 done


### PR DESCRIPTION
# Description

I replaced `! -z` with `-n` for checking non-empty values. Both are logically equivalent, but `-n` is more idiomatic and improves readability.

## Author Checklist

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] confirmed all CI checks have passed

## Reviewers Checklist

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [x] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage