### PR TITLE
fix: Remove FIXME and Update broken default verifier URL

### DIFF
--- a/cmd/move/verify.go
+++ b/cmd/move/verify.go
@@ -26,7 +26,7 @@ const (
 	flagVerifierURL = "verifier-url"
 )
 
-const defaultVerifierURL = "https://api.initia.tech/contracts/verify" // FIXME: set to real url
+const defaultVerifierURL = "https://api.testnet.initia.xyz/contracts/verify"
 
 const (
 	manifestFilename = "Move.toml"


### PR DESCRIPTION
# Description

This PR updates the broken default verifier URL from `https://api.initia.tech/contracts/verify` to `https://api.testnet.initia.tech/contracts/verify`, ensuring the correct endpoint is used.  

Additionally, the `FIXME` comment has been removed as the issue has been resolved.

## Author Checklist

- [X] confirmed `!` in the type prefix if API or client breaking change
- [X] targeted the correct branch
- [X] provided a link to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] included the necessary unit and integration tests
- [X] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
