### PR TITLE
style: replace unkeyed struct literals with keyed fields

### DIFF
--- a/x/distribution/types/dec_pool_test.go
+++ b/x/distribution/types/dec_pool_test.go
@@ -220,8 +220,12 @@ func (s *decpoolTestSuite) TestIsAnyNegativePools() {
 		expected bool
 	}{
 		{types.NewDecPoolsFromPools(types.NewPools(s.pool111, s.pool222, s.pool444)), false},
-		{types.DecPools{types.DecPool{"test", sdk.DecCoins{sdk.DecCoin{"testdenom", math.LegacyNewDecFromInt(math.NewInt(-10))}}}}, true},
-	}
+		{types.DecPools{types.DecPool{"test", sdk.DecCoins{
+                    {
+                        Denom:  "testdenom",
+                        Amount: math.LegacyNewDecFromInt(math.NewInt(-10)),
+                    },
+}}}, true},
 
 	for tcIndex, tc := range cases {
 		res := tc.input.IsAnyNegative()
@@ -295,28 +299,68 @@ func (s *decpoolTestSuite) TestSumPools() {
 }
 
 func (s *decpoolTestSuite) TestTruncatePools() {
-	cases := []struct {
-		input     types.DecPools
-		expected1 types.Pools
-		expected2 types.DecPools
-	}{
-		{
-			types.DecPools{types.DecPool{"test1", sdk.DecCoins{sdk.DecCoin{"testdenom1", math.LegacyNewDecFromIntWithPrec(math.NewInt(10500), 3)}}}},
-			types.Pools{types.Pool{"test1", sdk.Coins{sdk.Coin{"testdenom1", math.NewInt(10)}}}},
-			types.DecPools{types.DecPool{"test1", sdk.DecCoins{sdk.DecCoin{"testdenom1", math.LegacyNewDecFromIntWithPrec(math.NewInt(500), 3)}}}},
-		},
-		{
-			types.DecPools{types.DecPool{"test1", sdk.DecCoins{sdk.DecCoin{"testdenom1", math.LegacyNewDecFromIntWithPrec(math.NewInt(10000), 3)}}}},
-			types.Pools{types.Pool{"test1", sdk.Coins{sdk.Coin{"testdenom1", math.NewInt(10)}}}},
-			types.DecPools{},
-		},
-	}
+        cases := []struct {
+                input     types.DecPools
+                expected1 types.Pools
+                expected2 types.DecPools
+        }{
+                {
+                        types.DecPools{types.DecPool{
+                                Denom: "test1",
+                                Coins: sdk.DecCoins{
+                                        {
+                                                Denom:  "testdenom1",
+                                                Amount: math.LegacyNewDecFromIntWithPrec(math.NewInt(10500), 3),
+                                        },
+                                },
+                        }},
+                        types.Pools{types.Pool{
+                                Denom: "test1",
+                                Coins: sdk.Coins{
+                                        {
+                                                Denom:  "testdenom1",
+                                                Amount: math.NewInt(10),
+                                        },
+                                },
+                        }},
+                        types.DecPools{types.DecPool{
+                                Denom: "test1",
+                                Coins: sdk.DecCoins{
+                                        {
+                                                Denom:  "testdenom1",
+                                                Amount: math.LegacyNewDecFromIntWithPrec(math.NewInt(500), 3),
+                                        },
+                                },
+                        }},
+                },
+                {
+                        types.DecPools{types.DecPool{
+                                Denom: "test1",
+                                Coins: sdk.DecCoins{
+                                        {
+                                                Denom:  "testdenom1",
+                                                Amount: math.LegacyNewDecFromIntWithPrec(math.NewInt(10000), 3),
+                                        },
+                                },
+                        }},
+                        types.Pools{types.Pool{
+                                Denom: "test1",
+                                Coins: sdk.Coins{
+                                        {
+                                                Denom:  "testdenom1",
+                                                Amount: math.NewInt(10),
+                                        },
+                                },
+                        }},
+                        types.DecPools{},
+                },
+        }
 
-	for tcIndex, tc := range cases {
-		res1, res2 := tc.input.TruncateDecimal()
-		s.Require().True(tc.expected1.IsEqual(res1), "truncated pools are incorrect, tc #%d", tcIndex)
-		s.Require().True(tc.expected2.IsEqual(res2), "change pools are incorrect, tc #%d", tcIndex)
-	}
+        for tcIndex, tc := range cases {
+                res1, res2 := tc.input.TruncateDecimal()
+                s.Require().True(tc.expected1.IsEqual(res1), "truncated pools are incorrect, tc #%d", tcIndex)
+                s.Require().True(tc.expected2.IsEqual(res2), "change pools are incorrect, tc #%d", tcIndex)
+        }
 }
 
 func (s *decpoolTestSuite) TestIntersectPools() {


### PR DESCRIPTION
# Description

Replaced unkeyed struct literals with keyed fields in test files to comply with `go vet` and `golint` requirements.

### Before
Running `go vet ./...` caused the following error:
> `struct literal uses unkeyed fields`

![Before](https://github.com/user-attachments/assets/7307e1ac-a167-4bf9-b211-b2de6f7149af)

### After
The issue is resolved after the changes:

![After](https://github.com/user-attachments/assets/b35aca81-dc59-49a2-a60b-03610e5b0655)

No functionality was changed. This is a formatting-only change.

## Author Checklist

- [ ] confirmed `!` in the type prefix if API or client breaking change
- [X] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [X] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
