### PR TITLE
Refactor context usage and keeper calls

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -473,7 +473,7 @@ func (app *InitiaApp) Simulate(txBytes []byte) (sdk.GasInfo, *sdk.Result, error)
 
 // RegisterTxService implements the Application.RegisterTxService method.
 func (app *InitiaApp) RegisterTxService(clientCtx client.Context) {
-	authtx.RegisterTxService(app.BaseApp.GRPCQueryRouter(), clientCtx, app.Simulate, app.interfaceRegistry)
+	authtx.RegisterTxService(app.GRPCQueryRouter(), clientCtx, app.Simulate, app.interfaceRegistry)
 	initiatx.RegisterTxQuery(app.GRPCQueryRouter(), app.DynamicFeeKeeper)
 
 	// Register the Block SDK mempool transaction service.
@@ -488,7 +488,7 @@ func (app *InitiaApp) RegisterTxService(clientCtx client.Context) {
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (app *InitiaApp) RegisterTendermintService(clientCtx client.Context) {
 	cmtservice.RegisterTendermintService(
-		clientCtx, app.BaseApp.GRPCQueryRouter(),
+		clientCtx, app.GRPCQueryRouter(),
 		app.interfaceRegistry, app.Query,
 	)
 }

--- a/app/export.go
+++ b/app/export.go
@@ -49,7 +49,7 @@ func (app *InitiaApp) ExportAppStateAndValidators(
 		AppState:        appState,
 		Validators:      validators,
 		Height:          height,
-		ConsensusParams: app.BaseApp.GetConsensusParams(ctx),
+		ConsensusParams: app.GetConsensusParams(ctx),
 	}, nil
 }
 
@@ -58,12 +58,9 @@ func (app *InitiaApp) ExportAppStateAndValidators(
 //
 //	in favour of export at a block height
 func (app *InitiaApp) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) error {
-	applyAllowedAddrs := false
+	applyAllowedAddrs := len(jailAllowedAddrs) > 0
 
 	// check if there is a allowed address list
-	if len(jailAllowedAddrs) > 0 {
-		applyAllowedAddrs = true
-	}
 
 	allowedAddrsMap := make(map[string]bool)
 

--- a/crypto/ledger/usbwallet/wallet.go
+++ b/crypto/ledger/usbwallet/wallet.go
@@ -588,7 +588,7 @@ func (w *wallet) signPersonalMessage(account accounts.Account, data []byte) ([]b
 // SignData signs keccak256(data). The mimetype parameter describes the type of data being signed
 func (w *wallet) SignData(account accounts.Account, mimeType string, data []byte) ([]byte, error) {
 	// Unless we are doing 712 signing, simply dispatch to signHash
-	if !(mimeType == accounts.MimetypeTypedData && len(data) == 66 && data[0] == 0x19 && data[1] == 0x01) {
+	if mimeType != accounts.MimetypeTypedData || len(data) != 66 || data[0] != 0x19 || data[1] != 0x01 {
 		return w.signHash(account, crypto.Keccak256(data))
 	}
 

--- a/x/bank/keeper/custom_msg_server.go
+++ b/x/bank/keeper/custom_msg_server.go
@@ -33,7 +33,7 @@ func (ms customMsgServer) SetDenomMetadata(ctx context.Context, req *customtypes
 		return nil, err
 	}
 
-	ms.Keeper.SetDenomMetaData(ctx, req.Metadata)
+	ms.SetDenomMetaData(ctx, req.Metadata)
 
 	return &customtypes.MsgSetDenomMetadataResponse{}, nil
 }

--- a/x/distribution/keeper/custom_grpc_query.go
+++ b/x/distribution/keeper/custom_grpc_query.go
@@ -51,7 +51,7 @@ func (q CustomQueryServer) ValidatorOutstandingRewards(ctx context.Context, req 
 		return nil, err
 	}
 
-	rewards, err := q.Keeper.GetValidatorOutstandingRewards(ctx, valAdr)
+	rewards, err := q.GetValidatorOutstandingRewards(ctx, valAdr)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (q CustomQueryServer) ValidatorCommission(ctx context.Context, req *customt
 		return nil, err
 	}
 
-	commission, err := q.Keeper.GetValidatorAccumulatedCommission(ctx, valAdr)
+	commission, err := q.GetValidatorAccumulatedCommission(ctx, valAdr)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (q CustomQueryServer) ValidatorSlashes(ctx context.Context, req *customtype
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid validator address")
 	}
-	events, pageRes, err := query.CollectionFilteredPaginate(ctx, q.Keeper.ValidatorSlashEvents, req.Pagination,
+	events, pageRes, err := query.CollectionFilteredPaginate(ctx, q.ValidatorSlashEvents, req.Pagination,
 		func(key collections.Triple[[]byte, uint64, uint64], result customtypes.ValidatorSlashEvent) (bool, error) {
 			if result.ValidatorPeriod < req.StartingHeight || result.ValidatorPeriod > req.EndingHeight {
 				return false, nil

--- a/x/distribution/keeper/grpc_query.go
+++ b/x/distribution/keeper/grpc_query.go
@@ -110,7 +110,7 @@ func (q QueryServer) ValidatorOutstandingRewards(ctx context.Context, req *types
 	if err != nil {
 		return nil, err
 	}
-	rewards, err := q.Keeper.GetValidatorOutstandingRewards(ctx, valAddr)
+	rewards, err := q.GetValidatorOutstandingRewards(ctx, valAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (q QueryServer) ValidatorCommission(ctx context.Context, req *types.QueryVa
 	if err != nil {
 		return nil, err
 	}
-	commission, err := q.Keeper.GetValidatorAccumulatedCommission(ctx, valAddr)
+	commission, err := q.GetValidatorAccumulatedCommission(ctx, valAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (q QueryServer) ValidatorSlashes(ctx context.Context, req *types.QueryValid
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid validator address")
 	}
-	events, pageRes, err := query.CollectionFilteredPaginate(ctx, q.Keeper.ValidatorSlashEvents, req.Pagination,
+	events, pageRes, err := query.CollectionFilteredPaginate(ctx, q.ValidatorSlashEvents, req.Pagination,
 		func(key collections.Triple[[]byte, uint64, uint64], result customtypes.ValidatorSlashEvent) (bool, error) {
 			if result.ValidatorPeriod < req.StartingHeight || result.ValidatorPeriod > req.EndingHeight {
 				return false, nil

--- a/x/dynamic-fee/keeper/ante.go
+++ b/x/dynamic-fee/keeper/ante.go
@@ -18,7 +18,7 @@ func NewAnteKeeper(k *Keeper) AnteKeeper {
 }
 
 func (k AnteKeeper) BaseDenom(ctx context.Context) (string, error) {
-	return k.Keeper.baseDenomKeeper.BaseDenom(ctx)
+	return k.baseDenomKeeper.BaseDenom(ctx)
 }
 
 func (k AnteKeeper) GetBaseSpotPrice(ctx context.Context, denom string) (math.LegacyDec, error) {
@@ -28,5 +28,5 @@ func (k AnteKeeper) GetBaseSpotPrice(ctx context.Context, denom string) (math.Le
 	} else if baseDenom == denom {
 		return math.LegacyOneDec(), nil
 	}
-	return k.Keeper.tokenPriceKeeper.GetBaseSpotPrice(ctx, denom)
+	return k.tokenPriceKeeper.GetBaseSpotPrice(ctx, denom)
 }

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -234,7 +234,7 @@ func handleTallyResult(
 	// the deposit at this point since the proposal is converted to regular.
 	// As a result, the deposits are either deleted or refunded in all cases
 	// EXCEPT when an expedited proposal fails.
-	if !(proposal.Expedited && !passed) {
+	if !proposal.Expedited || passed {
 		if burnDeposits {
 			err = k.DeleteAndBurnDeposits(ctx, proposal.Id)
 		} else {

--- a/x/gov/keeper/custom_grpc_query.go
+++ b/x/gov/keeper/custom_grpc_query.go
@@ -86,7 +86,7 @@ func (q CustomQueryServer) Proposals(ctx context.Context, req *customtypes.Query
 				return false, err
 			}
 
-			has, err := q.Keeper.Votes.Has(ctx, collections.Join(p.Id, sdk.AccAddress(voter)))
+			has, err := q.Votes.Has(ctx, collections.Join(p.Id, sdk.AccAddress(voter)))
 			// if no error, vote found, matchVoter = true
 			matchVoter = err == nil && has
 		}
@@ -97,7 +97,7 @@ func (q CustomQueryServer) Proposals(ctx context.Context, req *customtypes.Query
 			if err != nil {
 				return false, err
 			}
-			has, err := q.Keeper.Deposits.Has(ctx, collections.Join(p.Id, sdk.AccAddress(depositor)))
+			has, err := q.Deposits.Has(ctx, collections.Join(p.Id, sdk.AccAddress(depositor)))
 			// if no error, deposit found, matchDepositor = true
 			matchDepositor = err == nil && has
 		}
@@ -139,11 +139,11 @@ func (q CustomQueryServer) TallyResult(ctx context.Context, req *customtypes.Que
 
 	var tallyResult customtypes.TallyResult
 
-	switch {
-	case proposal.Status == v1.StatusDepositPeriod:
+	switch proposal.Status {
+	case v1.StatusDepositPeriod:
 		tallyResult = customtypes.EmptyTallyResult()
 
-	case proposal.Status == v1.StatusPassed || proposal.Status == v1.StatusRejected:
+	case v1.StatusPassed, v1.StatusRejected:
 		tallyResult = proposal.FinalTallyResult
 
 	default:
@@ -153,7 +153,7 @@ func (q CustomQueryServer) TallyResult(ctx context.Context, req *customtypes.Que
 			return nil, err
 		}
 
-		_, _, _, tallyResult, err = q.Keeper.Tally(ctx, params, proposal)
+		_, _, _, tallyResult, err = q.Tally(ctx, params, proposal)
 		if err != nil {
 			return nil, err
 		}

--- a/x/gov/keeper/msg_server.go
+++ b/x/gov/keeper/msg_server.go
@@ -102,7 +102,7 @@ func (k msgServer) SubmitProposal(goCtx context.Context, msg *v1.MsgSubmitPropos
 		"submit proposal",
 	)
 
-	votingStarted, err := k.Keeper.AddDeposit(ctx, proposal.Id, proposer, msg.GetInitialDeposit())
+	votingStarted, err := k.AddDeposit(ctx, proposal.Id, proposer, msg.GetInitialDeposit())
 	if err != nil {
 		return nil, err
 	}
@@ -162,11 +162,11 @@ func (k msgServer) ExecLegacyContent(goCtx context.Context, msg *v1.MsgExecLegac
 	}
 
 	// Ensure that the content has a respective handler
-	if !k.Keeper.legacyRouter.HasRoute(content.ProposalRoute()) {
+	if !k.legacyRouter.HasRoute(content.ProposalRoute()) {
 		return nil, errors.Wrap(types.ErrNoProposalHandlerExists, content.ProposalRoute())
 	}
 
-	handler := k.Keeper.legacyRouter.GetRoute(content.ProposalRoute())
+	handler := k.legacyRouter.GetRoute(content.ProposalRoute())
 	if err := handler(ctx, content); err != nil {
 		return nil, errors.Wrapf(types.ErrInvalidProposalContent, "failed to run legacy handler %s, %+v", content.ProposalRoute(), err)
 	}
@@ -186,7 +186,7 @@ func (k msgServer) Vote(goCtx context.Context, msg *v1.MsgVote) (*v1.MsgVoteResp
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	err = k.Keeper.AddVote(ctx, msg.ProposalId, accAddr, v1.NewNonSplitVoteOption(msg.Option), msg.Metadata)
+	err = k.AddVote(ctx, msg.ProposalId, accAddr, v1.NewNonSplitVoteOption(msg.Option), msg.Metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (k msgServer) VoteWeighted(goCtx context.Context, msg *v1.MsgVoteWeighted) 
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	err := k.Keeper.AddVote(ctx, msg.ProposalId, accAddr, msg.Options, msg.Metadata)
+	err := k.AddVote(ctx, msg.ProposalId, accAddr, msg.Options, msg.Metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (k msgServer) Deposit(goCtx context.Context, msg *v1.MsgDeposit) (*v1.MsgDe
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	votingStarted, err := k.Keeper.AddDeposit(ctx, msg.ProposalId, accAddr, msg.Amount)
+	votingStarted, err := k.AddDeposit(ctx, msg.ProposalId, accAddr, msg.Amount)
 	if err != nil {
 		return nil, err
 	}

--- a/x/ibc/perm/keeper/grpc_query.go
+++ b/x/ibc/perm/keeper/grpc_query.go
@@ -35,7 +35,7 @@ func (q QueryServerImpl) ChannelStates(ctx context.Context, req *types.QueryChan
 func (q QueryServerImpl) ChannelState(ctx context.Context, req *types.QueryChannelStateRequest) (*types.QueryChannelStateResponse, error) {
 	ctx = sdk.UnwrapSDKContext(ctx)
 
-	channelState, err := q.Keeper.GetChannelState(ctx, req.PortId, req.ChannelId)
+	channelState, err := q.GetChannelState(ctx, req.PortId, req.ChannelId)
 	if err != nil {
 		return nil, err
 	}

--- a/x/ibc/perm/keeper/msg_server.go
+++ b/x/ibc/perm/keeper/msg_server.go
@@ -25,11 +25,11 @@ func NewMsgServerImpl(k *Keeper) MsgServer {
 
 // UpdateAdmin update channel relayer to restrict relaying operation of a channel to specific relayer.
 func (ms MsgServer) UpdateAdmin(ctx context.Context, req *types.MsgUpdateAdmin) (*types.MsgUpdateAdminResponse, error) {
-	if err := req.Validate(ms.Keeper.ac); err != nil {
+	if err := req.Validate(ms.ac); err != nil {
 		return nil, err
 	}
 
-	cs, err := ms.Keeper.GetChannelState(ctx, req.PortId, req.ChannelId)
+	cs, err := ms.GetChannelState(ctx, req.PortId, req.ChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func (ms MsgServer) UpdateAdmin(ctx context.Context, req *types.MsgUpdateAdmin) 
 	}
 
 	cs.Admin = req.Admin
-	err = ms.Keeper.SetChannelState(ctx, cs)
+	err = ms.SetChannelState(ctx, cs)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +67,11 @@ func (ms MsgServer) UpdateAdmin(ctx context.Context, req *types.MsgUpdateAdmin) 
 
 // UpdatePermissionedRelayers update channel relayer to restrict relaying operation of a channel to specific relayer.
 func (ms MsgServer) UpdatePermissionedRelayers(ctx context.Context, req *types.MsgUpdatePermissionedRelayers) (*types.MsgUpdatePermissionedRelayersResponse, error) {
-	if err := req.Validate(ms.Keeper.ac); err != nil {
+	if err := req.Validate(ms.ac); err != nil {
 		return nil, err
 	}
 
-	cs, err := ms.Keeper.GetChannelState(ctx, req.PortId, req.ChannelId)
+	cs, err := ms.GetChannelState(ctx, req.PortId, req.ChannelId)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (ms MsgServer) UpdatePermissionedRelayers(ctx context.Context, req *types.M
 	}
 
 	cs.Relayers = req.Relayers
-	err = ms.Keeper.SetChannelState(ctx, cs)
+	err = ms.SetChannelState(ctx, cs)
 	if err != nil {
 		return nil, err
 	}

--- a/x/move/client/cli/utils.go
+++ b/x/move/client/cli/utils.go
@@ -135,13 +135,14 @@ func bcsSerializeArg(argType string, arg string, s serde.Serializer, ac address.
 		return s.GetBytes(), err
 
 	case "bool":
-		if arg == "true" || arg == "True" {
+		switch arg {
+		case "true", "True":
 			err := s.SerializeBool(true)
 			return s.GetBytes(), err
-		} else if arg == "false" || arg == "False" {
+		case "false", "False":
 			err := s.SerializeBool(false)
 			return s.GetBytes(), err
-		} else {
+		default:
 			return nil, errors.New("unsupported bool value")
 		}
 

--- a/x/move/keeper/api.go
+++ b/x/move/keeper/api.go
@@ -62,7 +62,7 @@ func (api GoApi) AmountToShare(valBz []byte, metadata vmtypes.AccountAddress, am
 		return "0", err
 	}
 
-	denom, err := types.DenomFromMetadataAddress(api.ctx, api.Keeper.MoveBankKeeper(), metadata)
+	denom, err := types.DenomFromMetadataAddress(api.ctx, api.MoveBankKeeper(), metadata)
 	if err != nil {
 		return "0", err
 	}
@@ -78,7 +78,7 @@ func (api GoApi) ShareToAmount(valBz []byte, metadata vmtypes.AccountAddress, sh
 		return 0, err
 	}
 
-	denom, err := types.DenomFromMetadataAddress(api.ctx, api.Keeper.MoveBankKeeper(), metadata)
+	denom, err := types.DenomFromMetadataAddress(api.ctx, api.MoveBankKeeper(), metadata)
 	if err != nil {
 		return 0, err
 	}
@@ -134,7 +134,7 @@ func (api GoApi) Query(req vmtypes.QueryRequest, gasBalance uint64) ([]byte, uin
 	// use normal gas meter to meter gas consumption during query with max gas limit
 	sdkCtx := sdk.UnwrapSDKContext(api.ctx).WithGasMeter(storetypes.NewGasMeter(gasBalance))
 
-	res, err := api.Keeper.HandleVMQuery(sdkCtx, &req)
+	res, err := api.HandleVMQuery(sdkCtx, &req)
 	if err != nil {
 		return nil, sdkCtx.GasMeter().GasConsumed(), err
 	}

--- a/x/move/keeper/balancer.go
+++ b/x/move/keeper/balancer.go
@@ -105,11 +105,12 @@ func (k BalancerKeeper) Whitelist(ctx context.Context, metadataLP vmtypes.Accoun
 	}
 
 	var metadataQuote vmtypes.AccountAddress
-	if metadataBase == metadata[0] {
+	switch metadataBase {
+	case metadata[0]:
 		metadataQuote = metadata[1]
-	} else if metadataBase == metadata[1] {
+	case metadata[1]:
 		metadataQuote = metadata[0]
-	} else {
+	default:
 		return false, moderrors.Wrapf(
 			types.ErrInvalidDexConfig,
 			"To be whitelisted, a dex should contain `%s` in its pair", denomBase,
@@ -311,9 +312,10 @@ func (k BalancerKeeper) isReverse(
 		return false, err
 	}
 
-	if metadataBase == metadata[0] {
+	switch metadataBase {
+	case metadata[0]:
 		return false, nil
-	} else if metadataBase == metadata[1] {
+	case metadata[1]:
 		return true, nil
 	}
 

--- a/x/move/keeper/keeper.go
+++ b/x/move/keeper/keeper.go
@@ -564,7 +564,8 @@ func (k Keeper) walkVMStore(ctx context.Context, cb func(*types.Module, *types.C
 		}
 
 		cursor += 1
-		if separator == types.ModuleSeparator {
+		switch separator {
+		case types.ModuleSeparator:
 			// Module
 			moduleName, err := vmtypes.BcsDeserializeIdentifier(key[cursor:])
 			if err != nil {
@@ -582,7 +583,7 @@ func (k Keeper) walkVMStore(ctx context.Context, cb func(*types.Module, *types.C
 				RawBytes:      value,
 				UpgradePolicy: policy,
 			}, nil, nil, nil, nil)
-		} else if separator == types.ChecksumSeparator {
+		case types.ChecksumSeparator:
 			// Checksum
 			moduleName, err := vmtypes.BcsDeserializeIdentifier(key[cursor:])
 			if err != nil {
@@ -594,7 +595,7 @@ func (k Keeper) walkVMStore(ctx context.Context, cb func(*types.Module, *types.C
 				ModuleName: string(moduleName),
 				Checksum:   value,
 			}, nil, nil, nil)
-		} else if separator == types.ResourceSeparator {
+		case types.ResourceSeparator:
 			// Resource
 			structTag, err := vmtypes.BcsDeserializeStructTag(key[cursor:])
 			if err != nil {
@@ -611,7 +612,7 @@ func (k Keeper) walkVMStore(ctx context.Context, cb func(*types.Module, *types.C
 				StructTag: structTagStr,
 				RawBytes:  value,
 			}, nil, nil)
-		} else if separator == types.TableInfoSeparator {
+		case types.TableInfoSeparator:
 			// Table Info
 			tableInfo, err := vmtypes.BcsDeserializeTableInfo(value)
 			if err != nil {
@@ -633,14 +634,14 @@ func (k Keeper) walkVMStore(ctx context.Context, cb func(*types.Module, *types.C
 				KeyType:   keyType,
 				ValueType: valueType,
 			}, nil)
-		} else if separator == types.TableEntrySeparator {
+		case types.TableEntrySeparator:
 			// Table Entry
 			cb(nil, nil, nil, nil, &types.TableEntry{
 				Address:    vmAddr.String(),
 				KeyBytes:   key[cursor:],
 				ValueBytes: value,
 			})
-		} else {
+		default:
 			return true, errors.New("unknown prefix")
 		}
 

--- a/x/move/keeper/msg_server.go
+++ b/x/move/keeper/msg_server.go
@@ -43,7 +43,7 @@ func (ms MsgServer) Publish(context context.Context, req *types.MsgPublish) (*ty
 		modules = append(modules, vmtypes.NewModule(module))
 	}
 
-	err = ms.Keeper.PublishModuleBundle(
+	err = ms.PublishModuleBundle(
 		ctx,
 		sender,
 		vmtypes.NewModuleBundle(modules...),
@@ -80,7 +80,7 @@ func (ms MsgServer) Execute(context context.Context, req *types.MsgExecute) (*ty
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteEntryFunction(
+	err = ms.ExecuteEntryFunction(
 		ctx,
 		sender,
 		moduleAddr,
@@ -120,7 +120,7 @@ func (ms MsgServer) ExecuteJSON(context context.Context, req *types.MsgExecuteJS
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteEntryFunctionJSON(
+	err = ms.ExecuteEntryFunctionJSON(
 		ctx,
 		sender,
 		moduleAddr,
@@ -161,7 +161,7 @@ func (ms MsgServer) Script(ctx context.Context, req *types.MsgScript) (*types.Ms
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteScript(
+	err = ms.ExecuteScript(
 		ctx,
 		sender,
 		req.CodeBytes,
@@ -194,7 +194,7 @@ func (ms MsgServer) ScriptJSON(context context.Context, req *types.MsgScriptJSON
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteScriptJSON(
+	err = ms.ExecuteScriptJSON(
 		ctx,
 		sender,
 		req.CodeBytes,
@@ -231,7 +231,7 @@ func (ms MsgServer) GovPublish(context context.Context, req *types.MsgGovPublish
 		modules = append(modules, vmtypes.NewModule(module))
 	}
 
-	err = ms.Keeper.PublishModuleBundle(
+	err = ms.PublishModuleBundle(
 		ctx,
 		sender,
 		vmtypes.NewModuleBundle(modules...),
@@ -272,7 +272,7 @@ func (ms MsgServer) GovExecute(context context.Context, req *types.MsgGovExecute
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteEntryFunction(
+	err = ms.ExecuteEntryFunction(
 		ctx,
 		sender,
 		moduleAddr,
@@ -316,7 +316,7 @@ func (ms MsgServer) GovExecuteJSON(context context.Context, req *types.MsgGovExe
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteEntryFunctionJSON(
+	err = ms.ExecuteEntryFunctionJSON(
 		ctx,
 		sender,
 		moduleAddr,
@@ -355,7 +355,7 @@ func (ms MsgServer) GovScript(context context.Context, req *types.MsgGovScript) 
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteScript(
+	err = ms.ExecuteScript(
 		ctx,
 		sender,
 		req.CodeBytes,
@@ -392,7 +392,7 @@ func (ms MsgServer) GovScriptJSON(context context.Context, req *types.MsgGovScri
 		return nil, err
 	}
 
-	err = ms.Keeper.ExecuteScriptJSON(
+	err = ms.ExecuteScriptJSON(
 		ctx,
 		sender,
 		req.CodeBytes,

--- a/x/move/keeper/querier.go
+++ b/x/move/keeper/querier.go
@@ -49,7 +49,7 @@ func (q Querier) Modules(ctx context.Context, req *types.QueryModulesRequest) (*
 	}
 
 	prefixBytes := types.GetModulePrefix(moduleAddr)
-	modules, pageRes, err := query.CollectionPaginate(ctx, q.Keeper.VMStore, req.Pagination, func(key []byte, rawBytes []byte) (types.Module, error) {
+	modules, pageRes, err := query.CollectionPaginate(ctx, q.VMStore, req.Pagination, func(key []byte, rawBytes []byte) (types.Module, error) {
 		bz, err := q.DecodeModuleBytes(rawBytes)
 		if err != nil {
 			return types.Module{}, err
@@ -435,7 +435,7 @@ func (q Querier) Denom(ctx context.Context, req *types.QueryDenomRequest) (*type
 		return nil, err
 	}
 
-	denom, err := types.DenomFromMetadataAddress(ctx, q.Keeper.MoveBankKeeper(), metadata)
+	denom, err := types.DenomFromMetadataAddress(ctx, q.MoveBankKeeper(), metadata)
 	if err != nil {
 		return nil, err
 	}

--- a/x/move/keeper/vesting.go
+++ b/x/move/keeper/vesting.go
@@ -90,7 +90,7 @@ func (vk VestingKeeper) getVestingTokenDenom(ctx context.Context, moduleAccAddr 
 		return "", err
 	}
 
-	return types.DenomFromMetadataAddress(ctx, vk.Keeper.MoveBankKeeper(), vmtypes.AccountAddress(vestingTokenMetadata))
+	return types.DenomFromMetadataAddress(ctx, vk.MoveBankKeeper(), vmtypes.AccountAddress(vestingTokenMetadata))
 }
 
 // getVestingTableHandler returns the vesting table handle for the given module and creator

--- a/x/mstaking/keeper/compatibility_keeper.go
+++ b/x/mstaking/keeper/compatibility_keeper.go
@@ -22,7 +22,7 @@ func NewCompatibilityKeeper(k *Keeper) CompatibilityKeeper {
 }
 
 func (k CompatibilityKeeper) Validator(ctx context.Context, addr sdk.ValAddress) (cosmostypes.ValidatorI, error) {
-	val, err := k.Keeper.GetValidator(ctx, addr)
+	val, err := k.GetValidator(ctx, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (k CompatibilityKeeper) Validator(ctx context.Context, addr sdk.ValAddress)
 }
 
 func (k CompatibilityKeeper) ValidatorByConsAddr(ctx context.Context, addr sdk.ConsAddress) (cosmostypes.ValidatorI, error) {
-	val, err := k.Keeper.GetValidatorByConsAddr(ctx, addr)
+	val, err := k.GetValidatorByConsAddr(ctx, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/x/mstaking/keeper/msg_server.go
+++ b/x/mstaking/keeper/msg_server.go
@@ -524,7 +524,7 @@ func (k msgServer) CancelUnbondingDelegation(ctx context.Context, msg *types.Msg
 }
 
 func (ms msgServer) UpdateParams(ctx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
-	if err := msg.Validate(ms.Keeper.authKeeper.AddressCodec()); err != nil {
+	if err := msg.Validate(ms.authKeeper.AddressCodec()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Refactor context usage and keeper calls for consistency and clarity. Replaced direct or duplicate contexts, streamlined keeper method calls, and removed unused variables. This improves maintainability and aligns with best practices.