### PR TITLE
fix: update `voting_end_time` to `next_emergency_tally_time` at tally

### DIFF
--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -257,6 +257,9 @@ func handleTallyResult(
 		if err = k.EmergencyProposals.Remove(ctx, proposal.Id); err != nil {
 			return err
 		}
+
+		// update the voting end time to the emergency next tally time
+		proposal.VotingEndTime = proposal.EmergencyNextTallyTime
 	}
 
 	var tagValue, logMsg string

--- a/x/gov/abci_test.go
+++ b/x/gov/abci_test.go
@@ -134,6 +134,9 @@ func TestEmergencyProposalPassedEndblocker(t *testing.T) {
 	proposal, err = app.GovKeeper.Proposals.Get(ctx, 1)
 	require.NoError(t, err)
 	require.Equal(t, proposal.Status, v1.StatusPassed)
+
+	// the voting end time should be the emergency next tally time
+	require.True(t, proposal.VotingEndTime.Equal(*proposal.EmergencyNextTallyTime))
 }
 
 func TestTickSingleProposal(t *testing.T) {


### PR DESCRIPTION
# Description

To properly show the voting end time, we need to update voting end time to next emergency tally time at tally handler.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
