### PR TITLE
fix: skip upgrade handler registration if loadLatest is false

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -249,8 +249,14 @@ func NewInitiaApp(
 		tmos.Exit(err.Error())
 	}
 
-	// register upgrade handler for later use
-	app.RegisterUpgradeHandlers(app.configurator)
+	// Only register upgrade handlers when loading the latest version of the app.
+	// This optimization skips unnecessary handler registration during app initialization.
+	//
+	// The cosmos upgrade handler attempts to create ${HOME}/.initia/data to check for upgrade info,
+	// but this isn't required during initial encoding config setup.
+	if loadLatest {
+		app.RegisterUpgradeHandlers(app.configurator)
+	}
 
 	autocliv1.RegisterQueryServer(app.GRPCQueryRouter(), runtimeservices.NewAutoCLIQueryService(app.ModuleManager.Modules))
 

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -23,7 +23,7 @@ func newTempApp() *InitiaApp {
 		log.NewNopLogger(),
 		dbm.NewMemDB(),
 		nil,
-		true,
+		false,
 		moveconfig.DefaultMoveConfig(),
 		oracleconfig.NewDefaultAppConfig(),
 		EmptyAppOptions{},


### PR DESCRIPTION
# Description

Currently, upgrade handlers are being registered during the initial encoding configuration setup, which can lead to unintended side effects. Specifically, the Cosmos SDK's upgrade module attempts to create the ${HOME}/.initia/data directory to check for upgrade information, even though this is not required during early-stage setup.

This PR is to register upgrade handlers only when loading the latest version of the app. This optimization prevents unnecessary file system access and handler registration during app initialization, improving startup performance and avoiding redundant operations.

---

## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] included the necessary unit and integration tests
- [ ] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] confirmed all CI checks have passed

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
