### PR TITLE
fix: cap mempool priority overflow

### DIFF
--- a/x/dynamic-fee/ante/fee.go
+++ b/x/dynamic-fee/ante/fee.go
@@ -1,6 +1,8 @@
 package ante
 
 import (
+	stdmath "math"
+
 	"cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
@@ -28,6 +30,21 @@ func NewMempoolFeeChecker(
 		keeper,
 	}
 }
+
+func priorityFromGasPrice(gasPrice math.LegacyDec) int64 {
+	if !gasPrice.IsPositive() {
+		return 1
+	}
+
+	scaledPriority := gasPrice.MulInt64(1_000_000)
+	maxPriority := math.LegacyNewDecFromInt(math.NewInt(stdmath.MaxInt64))
+	if scaledPriority.GTE(maxPriority) {
+		return stdmath.MaxInt64
+	}
+
+	return math.Max(scaledPriority.TruncateInt64(), 1)
+}
+
 func (fc MempoolFeeChecker) CheckTxFeeWithMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {
@@ -69,8 +86,8 @@ func (fc MempoolFeeChecker) CheckTxFeeWithMinGasPrices(ctx sdk.Context, tx sdk.T
 
 			gasPriceFromTotalFee := math.LegacyNewDecFromInt(totalFeeBaseAmount).Quo(math.LegacyNewDec(int64(gas))) //nolint: gosec
 
-			// priority is max(gasPriceFromTotalFee * 1e6, 1)
-			priority = math.Max(gasPriceFromTotalFee.MulInt64(1000000).TruncateInt64(), 1)
+			// priority is max(gasPriceFromTotalFee * 1e6, 1), capped to int64 bounds.
+			priority = priorityFromGasPrice(gasPriceFromTotalFee)
 
 			if gasPriceFromTotalFee.LT(baseGasPrice) {
 				return nil, 0, errors.Wrapf(

--- a/x/dynamic-fee/ante/fee.go
+++ b/x/dynamic-fee/ante/fee.go
@@ -31,13 +31,18 @@ func NewMempoolFeeChecker(
 	}
 }
 
+var maxPriority math.LegacyDec
+
+func init() {
+	maxPriority = math.LegacyNewDecFromInt(math.NewInt(stdmath.MaxInt64))
+}
+
 func priorityFromGasPrice(gasPrice math.LegacyDec) int64 {
 	if !gasPrice.IsPositive() {
 		return 1
 	}
 
 	scaledPriority := gasPrice.MulInt64(1_000_000)
-	maxPriority := math.LegacyNewDecFromInt(math.NewInt(stdmath.MaxInt64))
 	if scaledPriority.GTE(maxPriority) {
 		return stdmath.MaxInt64
 	}

--- a/x/dynamic-fee/ante/fee_test.go
+++ b/x/dynamic-fee/ante/fee_test.go
@@ -3,6 +3,7 @@ package ante_test
 import (
 	"context"
 	"fmt"
+	stdmath "math"
 
 	"cosmossdk.io/math"
 
@@ -146,4 +147,44 @@ func (suite *AnteTestSuite) TestEnsureMempoolFees() {
 	suite.Require().Equal(feeAmount, tx.GetFee())
 	_, _, err = fc.CheckTxFeeWithMinGasPrices(suite.ctx, tx)
 	suite.Require().NotNil(err, "Decorator should have errored on too low fee for local gasPrice")
+}
+
+func (suite *AnteTestSuite) TestEnsureMempoolFees_PriorityOverflowCapped() {
+	suite.SetupTest()
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	fc := ante.NewMempoolFeeChecker(TestAnteKeeper{
+		pools: map[string][]math.Int{
+			"rare": {
+				math.NewInt(5_000_000_000_000_000_000),
+				math.OneInt(),
+			},
+		},
+		weights: map[string][]math.LegacyDec{
+			"rare": {
+				math.LegacyOneDec(),
+				math.LegacyOneDec(),
+			},
+		},
+		baseDenom:    baseDenom,
+		baseGasPrice: math.LegacyZeroDec(),
+	})
+
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	msg := testdata.NewTestMsg(addr1)
+
+	suite.Require().NoError(suite.txBuilder.SetMsgs(msg))
+	suite.txBuilder.SetFeeAmount(sdk.NewCoins(sdk.NewCoin("rare", math.OneInt())))
+	suite.txBuilder.SetGasLimit(1)
+
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1}, []uint64{0}, []uint64{0}
+	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	suite.ctx = suite.ctx.WithIsCheckTx(true)
+	suite.ctx = suite.ctx.WithMinGasPrices(nil)
+
+	_, priority, err := fc.CheckTxFeeWithMinGasPrices(suite.ctx, tx)
+	suite.Require().NoError(err)
+	suite.Require().Equal(int64(stdmath.MaxInt64), priority)
 }


### PR DESCRIPTION
## Summary
- cap mempool priority calculation at `math.MaxInt64`
- preserve existing fee checks while preventing `TruncateInt64()` overflow panics in `CheckTx`
- add regression coverage for a high-priced fee token case

## Why
- very large base-equivalent gas prices can overflow the mempool priority conversion path and panic during `CheckTx`

## Validation
- `go test ./x/dynamic-fee/ante -run 'TestAnteTestSuite/(TestEnsureMempoolFees|TestEnsureMempoolFees_PriorityOverflowCapped)$' -count=1`