### PR TITLE
!fix(move): route dex swaps through stdaddr

### DIFF
--- a/x/move/keeper/clamm_test.go
+++ b/x/move/keeper/clamm_test.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	vmtypes "github.com/initia-labs/movevm/types"
 
@@ -261,6 +262,31 @@ func Test_CLAMM_SwapToBase(t *testing.T) {
 	after := input.BankKeeper.GetAllBalances(ctx, fundedAddr)
 	require.True(t, before.AmountOf(quoteDenom).Sub(quoteOfferCoin.Amount).Equal(after.AmountOf(quoteDenom)))
 	require.True(t, before.AmountOf(baseDenom).Add(math.NewInt(1_000)).Equal(after.AmountOf(baseDenom)))
+}
+
+func Test_CLAMM_SwapToBase_BlockedRecipient(t *testing.T) {
+	ctx, input := createDefaultTestInput(t)
+
+	baseDenom := bondDenom
+	quoteDenom := "uusdc"
+	metadataQuote, err := types.MetadataAddressFromDenom(quoteDenom)
+	require.NoError(t, err)
+	metadataLP := createCLAMMPool(t, ctx, input, baseDenom, quoteDenom, 1, 0)
+
+	clammKeeper := keeper.NewCLAMMKeeper(&input.MoveKeeper, cafeAddr)
+
+	quoteOfferCoin := sdk.NewInt64Coin(quoteDenom, 1_000)
+	feeCollectorAddr := authtypes.NewModuleAddress(authtypes.FeeCollectorName)
+	input.Faucet.Fund(ctx, feeCollectorAddr, quoteOfferCoin)
+
+	err = clammKeeper.SwapToBase(
+		ctx,
+		types.ConvertSDKAddressToVMAddress(feeCollectorAddr),
+		metadataLP,
+		metadataQuote,
+		quoteOfferCoin.Amount,
+	)
+	require.Error(t, err)
 }
 
 func Test_CLAMM_SwapToBase_InvalidQuote(t *testing.T) {

--- a/x/move/keeper/dex.go
+++ b/x/move/keeper/dex.go
@@ -276,7 +276,9 @@ func (k DexKeeper) SwapToBase(
 	if ok, err := k.StableSwapKeeper().HasPool(ctx, metadataLP); err != nil {
 		return err
 	} else if ok {
-		return k.StableSwapKeeper().SwapToBase(ctx, vmAddr, metadataLP, metadataQuote, quoteCoin.Amount)
+		return k.swapToBaseViaStdAddr(ctx, addr, quoteCoin, func() error {
+			return k.StableSwapKeeper().SwapToBase(ctx, vmtypes.StdAddress, metadataLP, metadataQuote, quoteCoin.Amount)
+		})
 	}
 
 	params, err := k.GetParams(ctx)
@@ -293,37 +295,50 @@ func (k DexKeeper) SwapToBase(
 		if ok, err := clammKeeper.HasPool(ctx, metadataLP); err != nil {
 			return err
 		} else if ok {
-			baseDenom := params.BaseDenom
-			prevBaseBalance, err := k.moveBankKeeper.GetBalance(ctx, types.StdAddr, baseDenom)
-			if err != nil {
-				return err
-			}
-
-			// CLAMM cannot swap directly from blocked recipients such as the fee collector,
-			// so route the quote through StdAddr, execute the swap there, then send only
-			// the base-denom delta back to the original caller.
-			if err := k.moveBankKeeper.SendCoin(ctx, addr, types.StdAddr, quoteCoin.Denom, quoteCoin.Amount); err != nil {
-				return err
-			}
-			if err := clammKeeper.SwapToBase(ctx, vmtypes.StdAddress, metadataLP, metadataQuote, quoteCoin.Amount); err != nil {
-				return err
-			}
-
-			postBaseBalance, err := k.moveBankKeeper.GetBalance(ctx, types.StdAddr, baseDenom)
-			if err != nil {
-				return err
-			}
-
-			if postBaseBalance.GT(prevBaseBalance) {
-				baseBalanceDiff := postBaseBalance.Sub(prevBaseBalance)
-				if err := k.moveBankKeeper.SendCoin(ctx, types.StdAddr, addr, baseDenom, baseBalanceDiff); err != nil {
-					return err
-				}
-			}
-
-			return nil
+			return k.swapToBaseViaStdAddr(ctx, addr, quoteCoin, func() error {
+				return clammKeeper.SwapToBase(ctx, vmtypes.StdAddress, metadataLP, metadataQuote, quoteCoin.Amount)
+			})
 		}
 	}
 
 	return types.ErrInvalidRequest.Wrapf("LP `%s` is not a supported DEX pool", metadataLP.String())
+}
+
+func (k DexKeeper) swapToBaseViaStdAddr(
+	ctx context.Context,
+	addr sdk.AccAddress,
+	quoteCoin sdk.Coin,
+	swap func() error,
+) error {
+	params, err := k.GetParams(ctx)
+	if err != nil {
+		return err
+	}
+
+	baseDenom := params.BaseDenom
+	prevBaseBalance, err := k.moveBankKeeper.GetBalance(ctx, types.StdAddr, baseDenom)
+	if err != nil {
+		return err
+	}
+
+	if err := k.moveBankKeeper.SendCoin(ctx, addr, types.StdAddr, quoteCoin.Denom, quoteCoin.Amount); err != nil {
+		return err
+	}
+	if err := swap(); err != nil {
+		return err
+	}
+
+	postBaseBalance, err := k.moveBankKeeper.GetBalance(ctx, types.StdAddr, baseDenom)
+	if err != nil {
+		return err
+	}
+
+	if postBaseBalance.GT(prevBaseBalance) {
+		baseBalanceDiff := postBaseBalance.Sub(prevBaseBalance)
+		if err := k.moveBankKeeper.SendCoin(ctx, types.StdAddr, addr, baseDenom, baseBalanceDiff); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/x/move/keeper/dex_test.go
+++ b/x/move/keeper/dex_test.go
@@ -300,14 +300,18 @@ func TestDex_SwapToBase_StableSwap(t *testing.T) {
 
 	expectedOut := mustParseJSONUint64(t, simRes.Ret)
 	quoteOfferCoin := sdk.NewCoin(denomCoinB, math.NewIntFromUint64(offerAmount))
-	fundedAddr := input.Faucet.NewFundedAccount(ctx, quoteOfferCoin)
-	before := input.BankKeeper.GetAllBalances(ctx, fundedAddr)
+	feeCollectorAddr := authtypes.NewModuleAddress(authtypes.FeeCollectorName)
+	input.Faucet.Fund(ctx, feeCollectorAddr, quoteOfferCoin)
+	before := input.BankKeeper.GetAllBalances(ctx, feeCollectorAddr)
+	stdBaseBefore := input.BankKeeper.GetBalance(ctx, types.StdAddr, bondDenom).Amount
 
-	require.NoError(t, dexKeeper.SwapToBase(ctx, fundedAddr, quoteOfferCoin))
+	require.NoError(t, dexKeeper.SwapToBase(ctx, feeCollectorAddr, quoteOfferCoin))
 
-	after := input.BankKeeper.GetAllBalances(ctx, fundedAddr)
+	after := input.BankKeeper.GetAllBalances(ctx, feeCollectorAddr)
+	stdBaseAfter := input.BankKeeper.GetBalance(ctx, types.StdAddr, bondDenom).Amount
 	require.True(t, before.AmountOf(denomCoinB).Sub(math.NewIntFromUint64(offerAmount)).Equal(after.AmountOf(denomCoinB)))
 	require.True(t, before.AmountOf(bondDenom).Add(math.NewIntFromUint64(expectedOut)).Equal(after.AmountOf(bondDenom)))
+	require.True(t, stdBaseBefore.Equal(stdBaseAfter))
 }
 
 func TestDex_SwapToBase_UnsupportedPool(t *testing.T) {

--- a/x/move/keeper/stableswap_test.go
+++ b/x/move/keeper/stableswap_test.go
@@ -11,6 +11,7 @@ import (
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	vmtypes "github.com/initia-labs/movevm/types"
 
@@ -289,6 +290,40 @@ func Test_StableSwap_SwapToBase(t *testing.T) {
 	after := input.BankKeeper.GetAllBalances(ctx, fundedAddr)
 	require.True(t, before.AmountOf(denomCoinB).Sub(math.NewIntFromUint64(offerAmount)).Equal(after.AmountOf(denomCoinB)))
 	require.True(t, before.AmountOf(baseDenom).Add(math.NewIntFromUint64(expectedOut)).Equal(after.AmountOf(baseDenom)))
+}
+
+func Test_StableSwap_SwapToBase_BlockedRecipient(t *testing.T) {
+	ctx, input := createDefaultTestInput(t)
+	stableSwapKeeper := keeper.NewStableSwapKeeper(&input.MoveKeeper)
+
+	baseDenom := bondDenom
+	denomCoinB := "milkINIT"
+	denomCoinC := "ibiINIT"
+
+	metadataCoinB, err := types.MetadataAddressFromDenom(denomCoinB)
+	require.NoError(t, err)
+
+	metadataLP := createStableSwapPool(
+		t, ctx, input,
+		sdk.NewCoins(
+			sdk.NewCoin(baseDenom, math.NewInt(1_000_000_000_000)),
+			sdk.NewCoin(denomCoinB, math.NewInt(1_000_000_000_001)),
+			sdk.NewCoin(denomCoinC, math.NewInt(1_000_000_000_002)),
+		),
+	)
+
+	quoteOfferCoin := sdk.NewInt64Coin(denomCoinB, 1_000)
+	feeCollectorAddr := authtypes.NewModuleAddress(authtypes.FeeCollectorName)
+	input.Faucet.Fund(ctx, feeCollectorAddr, quoteOfferCoin)
+
+	err = stableSwapKeeper.SwapToBase(
+		ctx,
+		types.ConvertSDKAddressToVMAddress(feeCollectorAddr),
+		metadataLP,
+		metadataCoinB,
+		quoteOfferCoin.Amount,
+	)
+	require.Error(t, err)
 }
 
 func mustParseJSONUint64ForStableSwap(t *testing.T, raw string) uint64 {

--- a/x/move/keeper/whitelist.go
+++ b/x/move/keeper/whitelist.go
@@ -49,6 +49,10 @@ func (k Keeper) WhitelistGasPrice(ctx context.Context, msg types.MsgWhitelistGas
 	if stableswap, err := NewStableSwapKeeper(&k).WhitelistGasPrice(ctx, metadataQuote, metadataLP); err != nil {
 		return err
 	} else if stableswap {
+		// NOTE: Until the next upgrade, stableswap-backed gas-price swaps can still
+		// fail during execution and emit logs repeatedly. This does not affect chain
+		// liveness, but operators should avoid whitelisting stableswap pools for gas
+		// prices before that upgrade unless they accept the noisy failures.
 		return dexKeeper.setDexPair(ctx, metadataQuote, metadataLP)
 	}
 


### PR DESCRIPTION
# Description

Closes: N/A

Route DEX swap execution for blocked recipients through `StdAddr` in the dex layer instead of calling stableswap or CLAMM directly from the original recipient.

This change does three things:
- applies the existing `StdAddr` routing pattern to stableswap-backed dex swaps
- extracts the shared routing flow into a helper used by both stableswap and CLAMM paths in `DexKeeper`
- adds regression tests showing direct keeper swaps fail for blocked recipients like the fee collector, while dex-level swaps succeed through the routed path

Critical files to review:
- `x/move/keeper/dex.go`
- `x/move/keeper/dex_test.go`
- `x/move/keeper/stableswap_test.go`
- `x/move/keeper/clamm_test.go`

---

## Author Checklist

I have...

- [x] included the correct type prefix in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for documenting Go code
- [x] confirmed all CI checks have passed

Notes:
- breaking change: not applicable
- issue/spec link: N/A
- docs/spec update: not applicable for this internal keeper fix
- CI checks: local validation completed; GitHub CI pending on the PR

## Reviewers Checklist

I have...

- [ ] confirmed the correct type prefix in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
