### PR TITLE
feat: add quickstart command for node setup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   golangci:
     env:
-      GOLANGCI_LINT_VERSION: v2.2.2
+      GOLANGCI_LINT_VERSION: v2.11.4
     name: golangci-lint
     runs-on: ubuntu-22.04
     steps:

--- a/abcipp/mempool_test_utils_test.go
+++ b/abcipp/mempool_test_utils_test.go
@@ -15,7 +15,7 @@ import (
 
 // drainEvents reads buffered app-mempool events and returns inserted/removed counts.
 func drainEvents(ch <-chan cmtmempool.AppMempoolEvent) (inserted, removed int) {
-	const idleWindow = 2 * time.Millisecond
+	const idleWindow = 50 * time.Millisecond
 	const maxWait = 500 * time.Millisecond
 
 	idle := time.NewTimer(idleWindow)
@@ -49,7 +49,7 @@ func drainEvents(ch <-chan cmtmempool.AppMempoolEvent) (inserted, removed int) {
 
 // collectEvents returns buffered inserted/removed event tx bytes.
 func collectEvents(ch <-chan cmtmempool.AppMempoolEvent) (inserted, removed [][]byte) {
-	const idleWindow = 2 * time.Millisecond
+	const idleWindow = 50 * time.Millisecond
 	const maxWait = 500 * time.Millisecond
 
 	idle := time.NewTimer(idleWindow)

--- a/abcipp/proposals.go
+++ b/abcipp/proposals.go
@@ -155,7 +155,7 @@ func (h *ProposalHandler) PrepareProposalHandler() sdk.PrepareProposalHandler {
 					"tx_hash", TxHash(txInfo.TxBytes),
 				)
 
-				if txInfo.GasLimit > uint64(maxGasLimit) { //nolint:gosec
+				if txInfo.GasLimit > uint64(maxGasLimit) {
 					// Individually over-gas tx can never fit into a block, so remove it.
 					txsToRemove = append(txsToRemove, TxInfoEntry{Tx: tx, Info: txInfo})
 				}

--- a/cmd/initiad/appconfig/appconfig.go
+++ b/cmd/initiad/appconfig/appconfig.go
@@ -21,10 +21,10 @@ import (
 type InitiaAppConfig struct {
 	serverconfig.Config
 	ABCIPP     abcipp.AppConfig               `mapstructure:"abcipp"`
-	MoveConfig moveconfig.MoveConfig           `mapstructure:"move"`
-	Oracle     oracleconfig.AppConfig          `mapstructure:"oracle"`
-	MemIAVL    initiastorecfg.MemIAVLConfig    `mapstructure:"memiavl"`
-	VersionDB  initiastorecfg.VersionDBConfig  `mapstructure:"versiondb"`
+	MoveConfig moveconfig.MoveConfig          `mapstructure:"move"`
+	Oracle     oracleconfig.AppConfig         `mapstructure:"oracle"`
+	MemIAVL    initiastorecfg.MemIAVLConfig   `mapstructure:"memiavl"`
+	VersionDB  initiastorecfg.VersionDBConfig `mapstructure:"versiondb"`
 }
 
 // AppConfigTemplate returns the full app.toml template string.

--- a/cmd/initiad/appconfig/appconfig.go
+++ b/cmd/initiad/appconfig/appconfig.go
@@ -1,0 +1,92 @@
+package appconfig
+
+import (
+	"fmt"
+	"time"
+
+	oracleconfig "github.com/skip-mev/connect/v2/oracle/config"
+
+	tmcfg "github.com/cometbft/cometbft/config"
+
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/initia-labs/initia/abcipp"
+	initiaapp "github.com/initia-labs/initia/app"
+	moveconfig "github.com/initia-labs/initia/x/move/config"
+
+	initiastorecfg "github.com/initia-labs/store/config"
+)
+
+// InitiaAppConfig is the initia-specific app config that extends the SDK server config.
+type InitiaAppConfig struct {
+	serverconfig.Config
+	ABCIPP     abcipp.AppConfig               `mapstructure:"abcipp"`
+	MoveConfig moveconfig.MoveConfig           `mapstructure:"move"`
+	Oracle     oracleconfig.AppConfig          `mapstructure:"oracle"`
+	MemIAVL    initiastorecfg.MemIAVLConfig    `mapstructure:"memiavl"`
+	VersionDB  initiastorecfg.VersionDBConfig  `mapstructure:"versiondb"`
+}
+
+// AppConfigTemplate returns the full app.toml template string.
+func AppConfigTemplate() string {
+	return serverconfig.DefaultConfigTemplate +
+		abcipp.DefaultConfigTemplate +
+		moveconfig.DefaultConfigTemplate +
+		oracleconfig.DefaultConfigTemplate +
+		initiastorecfg.DefaultMemIAVLConfigTemplate +
+		initiastorecfg.DefaultVersionDBConfigTemplate
+}
+
+// InitAppConfig returns the default app config template and struct
+// with initia-specific defaults.
+func InitAppConfig() (string, *InitiaAppConfig) {
+	srvCfg := serverconfig.DefaultConfig()
+	srvCfg.MinGasPrices = fmt.Sprintf("0%s", initiaapp.BondDenom)
+	srvCfg.Mempool.MaxTxs = 2000
+	srvCfg.QueryGasLimit = 3000000
+	srvCfg.InterBlockCache = false
+
+	appConfig := &InitiaAppConfig{
+		Config:     *srvCfg,
+		ABCIPP:     abcipp.DefaultAppConfig(),
+		MoveConfig: moveconfig.DefaultMoveConfig(),
+		Oracle:     oracleconfig.NewDefaultAppConfig(),
+		MemIAVL:    initiastorecfg.DefaultMemIAVLConfig(),
+		VersionDB:  initiastorecfg.DefaultVersionDBConfig(),
+	}
+	appConfig.Oracle.ClientTimeout = 500 * time.Millisecond
+
+	return AppConfigTemplate(), appConfig
+}
+
+// InitTendermintConfig returns the default CometBFT config with initia-specific tuning.
+func InitTendermintConfig() *tmcfg.Config {
+	cfg := tmcfg.DefaultConfig()
+
+	// performance turning configs
+	cfg.P2P.SendRate = 20480000
+	cfg.P2P.RecvRate = 20480000
+	cfg.P2P.MaxPacketMsgPayloadSize = 1000000 // 1MB
+	cfg.P2P.FlushThrottleTimeout = 10 * time.Millisecond
+	cfg.Consensus.PeerGossipSleepDuration = 30 * time.Millisecond
+
+	// mempool configs
+	cfg.Mempool.Size = 1000
+	cfg.Mempool.MaxTxsBytes = 10737418240
+	cfg.Mempool.MaxTxBytes = 2048576
+
+	// set propose timeout to 3s and increase timeout by 500ms each round
+	cfg.Consensus.TimeoutPropose = 3 * time.Second
+	cfg.Consensus.TimeoutProposeDelta = 500 * time.Millisecond
+
+	// no need to increase wait timeout(delta) for prevote and precommit
+	cfg.Consensus.TimeoutPrevote = 500 * time.Millisecond
+	cfg.Consensus.TimeoutPrevoteDelta = 0 * time.Millisecond
+	cfg.Consensus.TimeoutPrecommit = 500 * time.Millisecond
+	cfg.Consensus.TimeoutPrecommitDelta = 0 * time.Millisecond
+
+	// set commit timeout to 2s
+	cfg.Consensus.TimeoutCommit = 2 * time.Second
+
+	return cfg
+}

--- a/cmd/initiad/config.go
+++ b/cmd/initiad/config.go
@@ -1,105 +1,20 @@
 package main
 
 import (
-	"fmt"
-	"time"
-
-	oracleconfig "github.com/skip-mev/connect/v2/oracle/config"
-
 	tmcfg "github.com/cometbft/cometbft/config"
 
-	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
-
-	"github.com/initia-labs/initia/abcipp"
-	initiaapp "github.com/initia-labs/initia/app"
-	moveconfig "github.com/initia-labs/initia/x/move/config"
-
-	initiastorecfg "github.com/initia-labs/store/config"
+	"github.com/initia-labs/initia/cmd/initiad/appconfig"
 )
-
-// initiaappConfig initia specify app config
-type initiaappConfig struct {
-	serverconfig.Config
-	ABCIPP     abcipp.AppConfig               `mapstructure:"abcipp"`
-	MoveConfig moveconfig.MoveConfig          `mapstructure:"move"`
-	Oracle     oracleconfig.AppConfig         `mapstructure:"oracle"`
-	MemIAVL    initiastorecfg.MemIAVLConfig   `mapstructure:"memiavl"`
-	VersionDB  initiastorecfg.VersionDBConfig `mapstructure:"versiondb"`
-}
 
 // initAppConfig helps to override default appConfig template and configs.
 // return "", nil if no custom configuration is required for the application.
 func initAppConfig() (string, any) {
-	// Optionally allow the chain developer to overwrite the SDK's default
-	// server config.
-	srvCfg := serverconfig.DefaultConfig()
-
-	// The SDK's default minimum gas price is set to "" (empty value) inside
-	// app.toml. If left empty by validators, the node will halt on startup.
-	// However, the chain developer can set a default app.toml value for their
-	// validators here.
-	//
-	// In summary:
-	// - if you leave srvCfg.MinGasPrices = "", all validators MUST tweak their
-	//   own app.toml config,
-	// - if you set srvCfg.MinGasPrices non-empty, validators CAN tweak their
-	//   own app.toml to override, or use this default value.
-	//
-	// In simapp, we set the min gas prices to 0.
-	srvCfg.MinGasPrices = fmt.Sprintf("0%s", initiaapp.BondDenom)
-	srvCfg.Mempool.MaxTxs = 2000
-	srvCfg.QueryGasLimit = 3000000
-	srvCfg.InterBlockCache = false
-
-	appConfig := initiaappConfig{
-		Config:     *srvCfg,
-		ABCIPP:     abcipp.DefaultAppConfig(),
-		MoveConfig: moveconfig.DefaultMoveConfig(),
-		Oracle:     oracleconfig.NewDefaultAppConfig(),
-		MemIAVL:    initiastorecfg.DefaultMemIAVLConfig(),
-		VersionDB:  initiastorecfg.DefaultVersionDBConfig(),
-	}
-	appConfig.Oracle.ClientTimeout = 500 * time.Millisecond
-
-	appConfigTemplate := serverconfig.DefaultConfigTemplate +
-		abcipp.DefaultConfigTemplate +
-		moveconfig.DefaultConfigTemplate +
-		oracleconfig.DefaultConfigTemplate +
-		initiastorecfg.DefaultMemIAVLConfigTemplate +
-		initiastorecfg.DefaultVersionDBConfigTemplate
-
-	return appConfigTemplate, appConfig
+	template, cfg := appconfig.InitAppConfig()
+	return template, cfg
 }
 
 // initTendermintConfig helps to override default Tendermint Config values.
 // return tmcfg.DefaultConfig if no custom configuration is required for the application.
 func initTendermintConfig() *tmcfg.Config {
-	cfg := tmcfg.DefaultConfig()
-
-	// performance turning configs
-	cfg.P2P.SendRate = 20480000
-	cfg.P2P.RecvRate = 20480000
-	cfg.P2P.MaxPacketMsgPayloadSize = 1000000 // 1MB
-	cfg.P2P.FlushThrottleTimeout = 10 * time.Millisecond
-	cfg.Consensus.PeerGossipSleepDuration = 30 * time.Millisecond
-
-	// mempool configs
-	cfg.Mempool.Size = 1000
-	cfg.Mempool.MaxTxsBytes = 10737418240
-	cfg.Mempool.MaxTxBytes = 2048576
-
-	// set propose timeout to 3s and increase timeout by 500ms each round
-	cfg.Consensus.TimeoutPropose = 3 * time.Second
-	cfg.Consensus.TimeoutProposeDelta = 500 * time.Millisecond
-
-	// no need to increase wait timeout(delta) for prevote and precommit
-	cfg.Consensus.TimeoutPrevote = 500 * time.Millisecond
-	cfg.Consensus.TimeoutPrevoteDelta = 0 * time.Millisecond
-	cfg.Consensus.TimeoutPrecommit = 500 * time.Millisecond
-	cfg.Consensus.TimeoutPrecommitDelta = 0 * time.Millisecond
-
-	// set commit timeout to 2s
-	cfg.Consensus.TimeoutCommit = 2 * time.Second
-
-	return cfg
+	return appconfig.InitTendermintConfig()
 }

--- a/cmd/initiad/quickstart/cmd.go
+++ b/cmd/initiad/quickstart/cmd.go
@@ -186,6 +186,11 @@ func readFromFlags(cmd *cobra.Command) (QuickstartConfig, error) {
 		return QuickstartConfig{}, fmt.Errorf("invalid pruning %q: must be %q, %q, %q, or %q", pruning, PruningDefault, PruningNothing, PruningEverything, PruningCustom)
 	}
 
+	// MemIAVL is not compatible with snapshot sync
+	if syncMethod == SyncSnapshot && memIAVL {
+		return QuickstartConfig{}, fmt.Errorf("--memiavl-enable cannot be used with --sync-method=snapshot")
+	}
+
 	return QuickstartConfig{
 		Network:           network,
 		SyncMethod:        syncMethod,

--- a/cmd/initiad/quickstart/cmd.go
+++ b/cmd/initiad/quickstart/cmd.go
@@ -265,23 +265,11 @@ func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
 	return QuickstartConfig{}, fmt.Errorf("not implemented")
 }
 
-func downloadGenesis(network, homeDir string) error {
-	return nil
-}
-
-func downloadAddrbook(network, homeDir string) error {
-	return nil
-}
-
 func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
 	return nil
 }
 
 func applyAppToml(cfg QuickstartConfig, homeDir string) error {
-	return nil
-}
-
-func setupStateSync(network, homeDir string) error {
 	return nil
 }
 

--- a/cmd/initiad/quickstart/cmd.go
+++ b/cmd/initiad/quickstart/cmd.go
@@ -1,0 +1,290 @@
+package quickstart
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	NetworkMainnet = "mainnet"
+	NetworkTestnet = "testnet"
+
+	SyncStateSync = "statesync"
+	SyncSnapshot  = "snapshot"
+
+	TxIndexNull    = "null"
+	TxIndexDefault = "default"
+	TxIndexCustom  = "custom"
+
+	PruningDefault    = "default"
+	PruningNothing    = "nothing"
+	PruningEverything = "everything"
+	PruningCustom     = "custom"
+
+	DefaultMinRetainBlocks = uint64(1_000_000)
+	DefaultAPIAddress      = "tcp://0.0.0.0:1317"
+	DefaultRPCAddress      = "tcp://127.0.0.1:26657"
+)
+
+var DefaultTxIndexingKeys = []string{
+	"tx.height",
+	"tx.hash",
+	"send_packet.packet_sequence",
+	"recv_packet.packet_sequence",
+	"write_acknowledgement.packet_sequence",
+	"acknowledge_packet.packet_sequence",
+	"timeout_packet.packet_sequence",
+	"finalize_token_deposit.l1_sequence",
+}
+
+const (
+	flagInteractive       = "interactive"
+	flagNetwork           = "network"
+	flagSyncMethod        = "sync-method"
+	flagSnapshotURL       = "snapshot-url"
+	flagTxIndexing        = "tx-indexing"
+	flagTxIndexingKeys    = "tx-indexing-keys"
+	flagPruning           = "pruning"
+	flagPruningKeepRecent = "pruning-keep-recent"
+	flagPruningInterval   = "pruning-interval"
+	flagMinRetainBlocks   = "min-retain-blocks"
+	flagMemIAVL           = "memiavl"
+	flagAPIAddress        = "api-address"
+	flagRPCAddress        = "rpc-address"
+)
+
+type QuickstartConfig struct {
+	Network           string
+	SyncMethod        string
+	SnapshotURL       string
+	TxIndexing        string
+	TxIndexingKeys    []string
+	Pruning           string
+	PruningKeepRecent string
+	PruningInterval   string
+	MinRetainBlocks   uint64
+	MemIAVL           bool
+	APIAddress        string
+	RPCAddress        string
+}
+
+// QuickstartCmd returns the cobra command for quickstart node setup.
+func QuickstartCmd(defaultNodeHome string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "quickstart",
+		Aliases: []string{"qstart", "qs"},
+		Short:   "Quickly configure and sync an Initia node",
+		Long: `Quickstart sets up an Initia node by downloading the genesis file,
+address book, and configuring sync method, pruning, indexing, and other settings.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			interactive, _ := cmd.Flags().GetBool(flagInteractive)
+
+			var cfg QuickstartConfig
+			var err error
+
+			if interactive {
+				cfg, err = runInteractive(cmd)
+				if err != nil {
+					return err
+				}
+			} else {
+				cfg, err = readFromFlags(cmd)
+				if err != nil {
+					return err
+				}
+			}
+
+			homeDir, _ := cmd.Flags().GetString("home")
+			if homeDir == "" {
+				homeDir = defaultNodeHome
+			}
+
+			return run(cfg, homeDir)
+		},
+	}
+
+	cmd.Flags().Bool(flagInteractive, false, "Run in interactive mode")
+	cmd.Flags().String(flagNetwork, NetworkMainnet, "Network to join (mainnet or testnet)")
+	cmd.Flags().String(flagSyncMethod, SyncStateSync, "Sync method (statesync or snapshot)")
+	cmd.Flags().String(flagSnapshotURL, "", "URL of the snapshot to download (required when sync-method=snapshot)")
+	cmd.Flags().String(flagTxIndexing, TxIndexDefault, "Transaction indexing mode (null, default, or custom)")
+	cmd.Flags().String(flagTxIndexingKeys, "", "Comma-separated list of tx indexing keys (required when tx-indexing=custom)")
+	cmd.Flags().String(flagPruning, PruningDefault, "Pruning strategy (default, nothing, everything, or custom)")
+	cmd.Flags().String(flagPruningKeepRecent, "", "Number of recent states to keep (required when pruning=custom)")
+	cmd.Flags().String(flagPruningInterval, "", "Pruning interval (required when pruning=custom)")
+	cmd.Flags().Uint64(flagMinRetainBlocks, DefaultMinRetainBlocks, "Minimum number of blocks to retain")
+	cmd.Flags().Bool(flagMemIAVL, true, "Enable MemIAVL for faster sync")
+	cmd.Flags().String(flagAPIAddress, DefaultAPIAddress, "API server listen address")
+	cmd.Flags().String(flagRPCAddress, DefaultRPCAddress, "RPC server listen address")
+
+	return cmd
+}
+
+// readFromFlags reads and validates QuickstartConfig from command flags.
+func readFromFlags(cmd *cobra.Command) (QuickstartConfig, error) {
+	network, _ := cmd.Flags().GetString(flagNetwork)
+	syncMethod, _ := cmd.Flags().GetString(flagSyncMethod)
+	snapshotURL, _ := cmd.Flags().GetString(flagSnapshotURL)
+	txIndexing, _ := cmd.Flags().GetString(flagTxIndexing)
+	txIndexingKeysRaw, _ := cmd.Flags().GetString(flagTxIndexingKeys)
+	pruning, _ := cmd.Flags().GetString(flagPruning)
+	pruningKeepRecent, _ := cmd.Flags().GetString(flagPruningKeepRecent)
+	pruningInterval, _ := cmd.Flags().GetString(flagPruningInterval)
+	minRetainBlocks, _ := cmd.Flags().GetUint64(flagMinRetainBlocks)
+	memIAVL, _ := cmd.Flags().GetBool(flagMemIAVL)
+	apiAddress, _ := cmd.Flags().GetString(flagAPIAddress)
+	rpcAddress, _ := cmd.Flags().GetString(flagRPCAddress)
+
+	// Validate network
+	if network != NetworkMainnet && network != NetworkTestnet {
+		return QuickstartConfig{}, fmt.Errorf("invalid network %q: must be %q or %q", network, NetworkMainnet, NetworkTestnet)
+	}
+
+	// Validate sync method
+	if syncMethod != SyncStateSync && syncMethod != SyncSnapshot {
+		return QuickstartConfig{}, fmt.Errorf("invalid sync-method %q: must be %q or %q", syncMethod, SyncStateSync, SyncSnapshot)
+	}
+
+	// Validate snapshot URL when using snapshot sync
+	if syncMethod == SyncSnapshot && snapshotURL == "" {
+		return QuickstartConfig{}, fmt.Errorf("--%s is required when --%s=%s", flagSnapshotURL, flagSyncMethod, SyncSnapshot)
+	}
+
+	// Validate tx indexing
+	if txIndexing != TxIndexNull && txIndexing != TxIndexDefault && txIndexing != TxIndexCustom {
+		return QuickstartConfig{}, fmt.Errorf("invalid tx-indexing %q: must be %q, %q, or %q", txIndexing, TxIndexNull, TxIndexDefault, TxIndexCustom)
+	}
+
+	// Resolve tx indexing keys
+	var txIndexingKeys []string
+	switch txIndexing {
+	case TxIndexCustom:
+		if txIndexingKeysRaw == "" {
+			return QuickstartConfig{}, fmt.Errorf("--%s is required when --%s=%s", flagTxIndexingKeys, flagTxIndexing, TxIndexCustom)
+		}
+		txIndexingKeys = splitAndTrim(txIndexingKeysRaw)
+	case TxIndexDefault:
+		txIndexingKeys = DefaultTxIndexingKeys
+	}
+
+	// Validate pruning
+	switch pruning {
+	case PruningDefault, PruningNothing, PruningEverything:
+		// valid
+	case PruningCustom:
+		if pruningKeepRecent == "" {
+			return QuickstartConfig{}, fmt.Errorf("--%s is required when --%s=%s", flagPruningKeepRecent, flagPruning, PruningCustom)
+		}
+		if pruningInterval == "" {
+			return QuickstartConfig{}, fmt.Errorf("--%s is required when --%s=%s", flagPruningInterval, flagPruning, PruningCustom)
+		}
+	default:
+		return QuickstartConfig{}, fmt.Errorf("invalid pruning %q: must be %q, %q, %q, or %q", pruning, PruningDefault, PruningNothing, PruningEverything, PruningCustom)
+	}
+
+	return QuickstartConfig{
+		Network:           network,
+		SyncMethod:        syncMethod,
+		SnapshotURL:       snapshotURL,
+		TxIndexing:        txIndexing,
+		TxIndexingKeys:    txIndexingKeys,
+		Pruning:           pruning,
+		PruningKeepRecent: pruningKeepRecent,
+		PruningInterval:   pruningInterval,
+		MinRetainBlocks:   minRetainBlocks,
+		MemIAVL:           memIAVL,
+		APIAddress:        apiAddress,
+		RPCAddress:        rpcAddress,
+	}, nil
+}
+
+// run executes the quickstart setup with the given config and home directory.
+func run(cfg QuickstartConfig, homeDir string) error {
+	configDir := filepath.Join(homeDir, "config")
+	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+		return fmt.Errorf("config directory %q does not exist; please run 'initiad init' first", configDir)
+	}
+
+	fmt.Println("Downloading genesis file...")
+	if err := downloadGenesis(cfg.Network, homeDir); err != nil {
+		return fmt.Errorf("failed to download genesis: %w", err)
+	}
+
+	fmt.Println("Downloading address book...")
+	if err := downloadAddrbook(cfg.Network, homeDir); err != nil {
+		return fmt.Errorf("failed to download address book: %w", err)
+	}
+
+	fmt.Println("Applying config.toml settings...")
+	if err := applyConfigToml(cfg, homeDir); err != nil {
+		return fmt.Errorf("failed to apply config.toml: %w", err)
+	}
+
+	fmt.Println("Applying app.toml settings...")
+	if err := applyAppToml(cfg, homeDir); err != nil {
+		return fmt.Errorf("failed to apply app.toml: %w", err)
+	}
+
+	switch cfg.SyncMethod {
+	case SyncStateSync:
+		fmt.Println("Setting up state sync...")
+		if err := setupStateSync(cfg.Network, homeDir); err != nil {
+			return fmt.Errorf("failed to set up state sync: %w", err)
+		}
+	case SyncSnapshot:
+		fmt.Println("Downloading and extracting snapshot...")
+		if err := downloadAndExtractSnapshot(cfg.SnapshotURL, homeDir); err != nil {
+			return fmt.Errorf("failed to download/extract snapshot: %w", err)
+		}
+	}
+
+	fmt.Println("Quickstart setup complete!")
+	return nil
+}
+
+// splitAndTrim splits a comma-separated string and trims whitespace from each element.
+func splitAndTrim(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// Stub functions — to be implemented in later tasks.
+
+func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
+	return QuickstartConfig{}, fmt.Errorf("not implemented")
+}
+
+func downloadGenesis(network, homeDir string) error {
+	return nil
+}
+
+func downloadAddrbook(network, homeDir string) error {
+	return nil
+}
+
+func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
+	return nil
+}
+
+func applyAppToml(cfg QuickstartConfig, homeDir string) error {
+	return nil
+}
+
+func setupStateSync(network, homeDir string) error {
+	return nil
+}
+
+func downloadAndExtractSnapshot(url, homeDir string) error {
+	return nil
+}

--- a/cmd/initiad/quickstart/cmd.go
+++ b/cmd/initiad/quickstart/cmd.go
@@ -263,5 +263,3 @@ func splitAndTrim(s string) []string {
 	}
 	return result
 }
-
-

--- a/cmd/initiad/quickstart/cmd.go
+++ b/cmd/initiad/quickstart/cmd.go
@@ -176,10 +176,10 @@ func readFromFlags(cmd *cobra.Command) (QuickstartConfig, error) {
 	case PruningDefault, PruningNothing, PruningEverything:
 		// valid
 	case PruningCustom:
-		if pruningKeepRecent == "" {
+		if !cmd.Flags().Changed(flagPruningKeepRecent) {
 			return QuickstartConfig{}, fmt.Errorf("--%s is required when --%s=%s", flagPruningKeepRecent, flagPruning, PruningCustom)
 		}
-		if pruningInterval == "" {
+		if !cmd.Flags().Changed(flagPruningInterval) {
 			return QuickstartConfig{}, fmt.Errorf("--%s is required when --%s=%s", flagPruningInterval, flagPruning, PruningCustom)
 		}
 	default:

--- a/cmd/initiad/quickstart/cmd.go
+++ b/cmd/initiad/quickstart/cmd.go
@@ -52,7 +52,7 @@ const (
 	flagPruningKeepRecent = "pruning-keep-recent"
 	flagPruningInterval   = "pruning-interval"
 	flagMinRetainBlocks   = "min-retain-blocks"
-	flagMemIAVL           = "memiavl"
+	flagMemIAVL           = "memiavl-enable"
 	flagAPIAddress        = "api-address"
 	flagRPCAddress        = "rpc-address"
 )
@@ -108,17 +108,17 @@ address book, and configuring sync method, pruning, indexing, and other settings
 	}
 
 	cmd.Flags().Bool(flagInteractive, false, "Run in interactive mode")
-	cmd.Flags().String(flagNetwork, NetworkMainnet, "Network to join (mainnet or testnet)")
-	cmd.Flags().String(flagSyncMethod, SyncStateSync, "Sync method (statesync or snapshot)")
+	cmd.Flags().String(flagNetwork, "", "Network to join (mainnet or testnet)")
+	cmd.Flags().String(flagSyncMethod, "", "Sync method (statesync or snapshot)")
 	cmd.Flags().String(flagSnapshotURL, "", "URL of the snapshot to download (required when sync-method=snapshot)")
-	cmd.Flags().String(flagTxIndexing, TxIndexDefault, "Transaction indexing mode (null, default, or custom)")
+	cmd.Flags().String(flagTxIndexing, "", "Transaction indexing mode (null, default, or custom)")
 	cmd.Flags().String(flagTxIndexingKeys, "", "Comma-separated list of tx indexing keys (required when tx-indexing=custom)")
-	cmd.Flags().String(flagPruning, PruningDefault, "Pruning strategy (default, nothing, everything, or custom)")
-	cmd.Flags().String(flagPruningKeepRecent, "", "Number of recent states to keep (required when pruning=custom)")
-	cmd.Flags().String(flagPruningInterval, "", "Pruning interval (required when pruning=custom)")
+	cmd.Flags().String(flagPruning, "", "Pruning strategy (default, nothing, everything, or custom)")
+	cmd.Flags().String(flagPruningKeepRecent, "0", "Number of recent states to keep (required when pruning=custom)")
+	cmd.Flags().String(flagPruningInterval, "0", "Pruning interval (required when pruning=custom)")
 	cmd.Flags().Uint64(flagMinRetainBlocks, DefaultMinRetainBlocks, "Minimum number of blocks to retain")
-	cmd.Flags().Bool(flagMemIAVL, true, "Enable MemIAVL for faster sync")
-	cmd.Flags().String(flagAPIAddress, DefaultAPIAddress, "API server listen address")
+	cmd.Flags().Bool(flagMemIAVL, false, "Enable MemIAVL")
+	cmd.Flags().String(flagAPIAddress, "", "REST API listen address (enables API if set)")
 	cmd.Flags().String(flagRPCAddress, DefaultRPCAddress, "RPC server listen address")
 
 	return cmd
@@ -259,20 +259,4 @@ func splitAndTrim(s string) []string {
 	return result
 }
 
-// Stub functions — to be implemented in later tasks.
 
-func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
-	return QuickstartConfig{}, fmt.Errorf("not implemented")
-}
-
-func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
-	return nil
-}
-
-func applyAppToml(cfg QuickstartConfig, homeDir string) error {
-	return nil
-}
-
-func downloadAndExtractSnapshot(url, homeDir string) error {
-	return nil
-}

--- a/cmd/initiad/quickstart/cmd_test.go
+++ b/cmd/initiad/quickstart/cmd_test.go
@@ -1,0 +1,155 @@
+package quickstart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadFromFlags_ValidMainnetStateSync(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "statesync")
+	cmd.Flags().Set("tx-indexing", "default")
+	cmd.Flags().Set("pruning", "default")
+
+	cfg, err := readFromFlags(cmd)
+	require.NoError(t, err)
+	require.Equal(t, "mainnet", cfg.Network)
+	require.Equal(t, "statesync", cfg.SyncMethod)
+	require.Equal(t, "", cfg.SnapshotURL)
+	require.Equal(t, "default", cfg.TxIndexing)
+	require.Equal(t, DefaultTxIndexingKeys, cfg.TxIndexingKeys)
+	require.Equal(t, "default", cfg.Pruning)
+}
+
+func TestReadFromFlags_ValidSnapshot(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "testnet")
+	cmd.Flags().Set("sync-method", "snapshot")
+	cmd.Flags().Set("snapshot-url", "https://example.com/snap.tar.lz4")
+	cmd.Flags().Set("tx-indexing", "null")
+	cmd.Flags().Set("pruning", "nothing")
+
+	cfg, err := readFromFlags(cmd)
+	require.NoError(t, err)
+	require.Equal(t, "testnet", cfg.Network)
+	require.Equal(t, "snapshot", cfg.SyncMethod)
+	require.Equal(t, "https://example.com/snap.tar.lz4", cfg.SnapshotURL)
+	require.Equal(t, "null", cfg.TxIndexing)
+	require.Nil(t, cfg.TxIndexingKeys)
+	require.Equal(t, "nothing", cfg.Pruning)
+}
+
+func TestReadFromFlags_CustomPruning(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "statesync")
+	cmd.Flags().Set("tx-indexing", "default")
+	cmd.Flags().Set("pruning", "custom")
+	cmd.Flags().Set("pruning-keep-recent", "1000")
+	cmd.Flags().Set("pruning-interval", "10")
+
+	cfg, err := readFromFlags(cmd)
+	require.NoError(t, err)
+	require.Equal(t, "custom", cfg.Pruning)
+	require.Equal(t, "1000", cfg.PruningKeepRecent)
+	require.Equal(t, "10", cfg.PruningInterval)
+}
+
+func TestReadFromFlags_CustomTxIndexing(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "statesync")
+	cmd.Flags().Set("tx-indexing", "custom")
+	cmd.Flags().Set("tx-indexing-keys", "key1,key2,key3")
+	cmd.Flags().Set("pruning", "default")
+
+	cfg, err := readFromFlags(cmd)
+	require.NoError(t, err)
+	require.Equal(t, "custom", cfg.TxIndexing)
+	require.Equal(t, []string{"key1", "key2", "key3"}, cfg.TxIndexingKeys)
+}
+
+func TestReadFromFlags_InvalidNetwork(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "invalid")
+	cmd.Flags().Set("sync-method", "statesync")
+	cmd.Flags().Set("tx-indexing", "default")
+	cmd.Flags().Set("pruning", "default")
+
+	_, err := readFromFlags(cmd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "mainnet")
+	require.Contains(t, err.Error(), "testnet")
+}
+
+func TestReadFromFlags_InvalidSyncMethod(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "invalid")
+	cmd.Flags().Set("tx-indexing", "default")
+	cmd.Flags().Set("pruning", "default")
+
+	_, err := readFromFlags(cmd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid sync-method")
+}
+
+func TestReadFromFlags_SnapshotMissingURL(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "snapshot")
+	cmd.Flags().Set("tx-indexing", "default")
+	cmd.Flags().Set("pruning", "default")
+
+	_, err := readFromFlags(cmd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "snapshot-url")
+}
+
+func TestReadFromFlags_InvalidTxIndexing(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "statesync")
+	cmd.Flags().Set("tx-indexing", "invalid")
+	cmd.Flags().Set("pruning", "default")
+
+	_, err := readFromFlags(cmd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid tx-indexing")
+}
+
+func TestReadFromFlags_CustomTxIndexingMissingKeys(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "statesync")
+	cmd.Flags().Set("tx-indexing", "custom")
+	cmd.Flags().Set("pruning", "default")
+
+	_, err := readFromFlags(cmd)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tx-indexing-keys")
+}
+
+func TestReadFromFlags_DefaultTxIndexingKeys(t *testing.T) {
+	cmd := QuickstartCmd("")
+	cmd.SetArgs([]string{})
+	cmd.Flags().Set("network", "mainnet")
+	cmd.Flags().Set("sync-method", "statesync")
+	cmd.Flags().Set("tx-indexing", "default")
+	cmd.Flags().Set("pruning", "default")
+
+	cfg, err := readFromFlags(cmd)
+	require.NoError(t, err)
+	require.Equal(t, DefaultTxIndexingKeys, cfg.TxIndexingKeys)
+}

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -37,7 +37,11 @@ func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
 
 	// TX index retain-height follows min-retain-blocks (only when indexing is enabled)
 	if cfg.TxIndexing != TxIndexNull {
-		cmtCfg.TxIndex.RetainHeight = int64(min(cfg.MinRetainBlocks, uint64(math.MaxInt64))) //nolint:gosec
+		if cfg.MinRetainBlocks > math.MaxInt64 {
+			cmtCfg.TxIndex.RetainHeight = math.MaxInt64
+		} else {
+			cmtCfg.TxIndex.RetainHeight = int64(cfg.MinRetainBlocks)
+		}
 	} else {
 		cmtCfg.TxIndex.RetainHeight = 0
 	}

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -80,6 +80,9 @@ func applyAppToml(cfg QuickstartConfig, homeDir string) error {
 	if cfg.Pruning == PruningCustom {
 		appCfg.PruningKeepRecent = cfg.PruningKeepRecent
 		appCfg.PruningInterval = cfg.PruningInterval
+	} else {
+		appCfg.PruningKeepRecent = "0"
+		appCfg.PruningInterval = "0"
 	}
 
 	// Min retain blocks (block pruning)

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -10,33 +10,8 @@ import (
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 
-	"github.com/initia-labs/initia/abcipp"
-	moveconfig "github.com/initia-labs/initia/x/move/config"
-
-	oracleconfig "github.com/skip-mev/connect/v2/oracle/config"
-
-	initiastorecfg "github.com/initia-labs/store/config"
+	"github.com/initia-labs/initia/cmd/initiad/appconfig"
 )
-
-// appConfig mirrors initiaappConfig from cmd/initiad/config.go
-// to support template-based writing that preserves comments.
-type appConfig struct {
-	serverconfig.Config
-	ABCIPP     abcipp.AppConfig               `mapstructure:"abcipp"`
-	MoveConfig moveconfig.MoveConfig           `mapstructure:"move"`
-	Oracle     oracleconfig.AppConfig          `mapstructure:"oracle"`
-	MemIAVL    initiastorecfg.MemIAVLConfig    `mapstructure:"memiavl"`
-	VersionDB  initiastorecfg.VersionDBConfig  `mapstructure:"versiondb"`
-}
-
-func appConfigTemplate() string {
-	return serverconfig.DefaultConfigTemplate +
-		abcipp.DefaultConfigTemplate +
-		moveconfig.DefaultConfigTemplate +
-		oracleconfig.DefaultConfigTemplate +
-		initiastorecfg.DefaultMemIAVLConfigTemplate +
-		initiastorecfg.DefaultVersionDBConfigTemplate
-}
 
 // applyConfigToml modifies config.toml: rpc address, tx_index, retain-height.
 func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
@@ -106,14 +81,13 @@ func applyAppToml(cfg QuickstartConfig, homeDir string) error {
 	appCfg.MemIAVL.Enable = cfg.MemIAVL
 
 	// Write back using template to preserve comments
-	serverconfig.SetConfigTemplate(appConfigTemplate())
+	serverconfig.SetConfigTemplate(appconfig.AppConfigTemplate())
 	serverconfig.WriteConfigFile(appCfgFile, appCfg)
 	return nil
 }
 
 // loadAppConfig reads app.toml via viper and unmarshals into the app config struct.
-// Uses Squash option to properly handle embedded BaseConfig fields.
-func loadAppConfig(configPath string) (*appConfig, error) {
+func loadAppConfig(configPath string) (*appconfig.InitiaAppConfig, error) {
 	v := viper.New()
 	v.SetConfigType("toml")
 	v.SetConfigName("app")
@@ -123,12 +97,34 @@ func loadAppConfig(configPath string) (*appConfig, error) {
 		return nil, err
 	}
 
-	cfg := &appConfig{}
+	cfg := &appconfig.InitiaAppConfig{}
 	if err := v.Unmarshal(cfg, func(dc *mapstructure.DecoderConfig) {
 		dc.Squash = true
 	}); err != nil {
 		return nil, err
 	}
 
+	return cfg, nil
+}
+
+// loadCometConfig reads config.toml via viper and unmarshals into a CometBFT Config struct.
+func loadCometConfig(configPath string) (*cmtcfg.Config, error) {
+	v := viper.New()
+	v.SetConfigType("toml")
+	v.SetConfigName("config")
+	v.AddConfigPath(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+
+	cfg := cmtcfg.DefaultConfig()
+	if err := v.Unmarshal(cfg, func(dc *mapstructure.DecoderConfig) {
+		dc.Squash = true
+	}); err != nil {
+		return nil, err
+	}
+
+	cfg.SetRoot(filepath.Dir(configPath))
 	return cfg, nil
 }

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -5,11 +5,11 @@ import (
 	"path/filepath"
 
 	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 
-	initiaapp "github.com/initia-labs/initia/app"
 	"github.com/initia-labs/initia/abcipp"
 	moveconfig "github.com/initia-labs/initia/x/move/config"
 
@@ -111,27 +111,8 @@ func applyAppToml(cfg QuickstartConfig, homeDir string) error {
 	return nil
 }
 
-// defaultAppConfig returns an appConfig initialized with the same defaults
-// that initiad init uses, so fields not modified by quickstart retain their values.
-func defaultAppConfig() *appConfig {
-	srvCfg := serverconfig.DefaultConfig()
-	srvCfg.MinGasPrices = fmt.Sprintf("0%s", initiaapp.BondDenom)
-	srvCfg.Mempool.MaxTxs = 2000
-	srvCfg.QueryGasLimit = 3000000
-	srvCfg.InterBlockCache = false
-
-	return &appConfig{
-		Config:     *srvCfg,
-		ABCIPP:     abcipp.DefaultAppConfig(),
-		MoveConfig: moveconfig.DefaultMoveConfig(),
-		Oracle:     oracleconfig.NewDefaultAppConfig(),
-		MemIAVL:    initiastorecfg.DefaultMemIAVLConfig(),
-		VersionDB:  initiastorecfg.DefaultVersionDBConfig(),
-	}
-}
-
 // loadAppConfig reads app.toml via viper and unmarshals into the app config struct.
-// Starts from initiad's default values so unset fields keep their defaults.
+// Uses Squash option to properly handle embedded BaseConfig fields.
 func loadAppConfig(configPath string) (*appConfig, error) {
 	v := viper.New()
 	v.SetConfigType("toml")
@@ -142,8 +123,10 @@ func loadAppConfig(configPath string) (*appConfig, error) {
 		return nil, err
 	}
 
-	cfg := defaultAppConfig()
-	if err := v.Unmarshal(cfg); err != nil {
+	cfg := &appConfig{}
+	if err := v.Unmarshal(cfg, func(dc *mapstructure.DecoderConfig) {
+		dc.Squash = true
+	}); err != nil {
 		return nil, err
 	}
 

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -1,0 +1,127 @@
+package quickstart
+
+import (
+	"fmt"
+	"path/filepath"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/spf13/viper"
+
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/initia-labs/initia/abcipp"
+	moveconfig "github.com/initia-labs/initia/x/move/config"
+
+	oracleconfig "github.com/skip-mev/connect/v2/oracle/config"
+
+	initiastorecfg "github.com/initia-labs/store/config"
+)
+
+// appConfig mirrors initiaappConfig from cmd/initiad/config.go
+// to support template-based writing that preserves comments.
+type appConfig struct {
+	serverconfig.Config
+	ABCIPP     abcipp.AppConfig               `mapstructure:"abcipp"`
+	MoveConfig moveconfig.MoveConfig           `mapstructure:"move"`
+	Oracle     oracleconfig.AppConfig          `mapstructure:"oracle"`
+	MemIAVL    initiastorecfg.MemIAVLConfig    `mapstructure:"memiavl"`
+	VersionDB  initiastorecfg.VersionDBConfig  `mapstructure:"versiondb"`
+}
+
+func appConfigTemplate() string {
+	return serverconfig.DefaultConfigTemplate +
+		abcipp.DefaultConfigTemplate +
+		moveconfig.DefaultConfigTemplate +
+		oracleconfig.DefaultConfigTemplate +
+		initiastorecfg.DefaultMemIAVLConfigTemplate +
+		initiastorecfg.DefaultVersionDBConfigTemplate
+}
+
+// applyConfigToml modifies config.toml: rpc address, tx_index, retain-height.
+func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
+	configPath := filepath.Join(homeDir, "config")
+	configFile := filepath.Join(configPath, "config.toml")
+
+	cmtCfg, err := loadCometConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config.toml: %w", err)
+	}
+
+	// RPC listen address
+	cmtCfg.RPC.ListenAddress = cfg.RPCAddress
+
+	// TX indexing
+	switch cfg.TxIndexing {
+	case TxIndexNull:
+		cmtCfg.TxIndex.Indexer = "null"
+	case TxIndexDefault, TxIndexCustom:
+		cmtCfg.TxIndex.Indexer = "kv"
+	}
+
+	// TX index retain-height follows min-retain-blocks
+	cmtCfg.TxIndex.RetainHeight = int64(cfg.MinRetainBlocks)
+
+	cmtcfg.WriteConfigFile(configFile, cmtCfg)
+	return nil
+}
+
+// applyAppToml modifies app.toml: pruning, min-retain-blocks, api, memiavl, index-events.
+func applyAppToml(cfg QuickstartConfig, homeDir string) error {
+	configPath := filepath.Join(homeDir, "config")
+	appCfgFile := filepath.Join(configPath, "app.toml")
+
+	appCfg, err := loadAppConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load app.toml: %w", err)
+	}
+
+	// Pruning
+	appCfg.Pruning = cfg.Pruning
+	if cfg.Pruning == PruningCustom {
+		appCfg.PruningKeepRecent = cfg.PruningKeepRecent
+		appCfg.PruningInterval = cfg.PruningInterval
+	}
+
+	// Min retain blocks (block pruning)
+	appCfg.MinRetainBlocks = cfg.MinRetainBlocks
+
+	// Index events (the event keys to index)
+	if cfg.TxIndexing == TxIndexDefault || cfg.TxIndexing == TxIndexCustom {
+		appCfg.IndexEvents = cfg.TxIndexingKeys
+	} else {
+		appCfg.IndexEvents = []string{}
+	}
+
+	// REST API
+	if cfg.APIAddress != "" {
+		appCfg.API.Enable = true
+		appCfg.API.Address = cfg.APIAddress
+	}
+
+	// MemIAVL
+	appCfg.MemIAVL.Enable = cfg.MemIAVL
+
+	// Write back using template to preserve comments
+	serverconfig.SetConfigTemplate(appConfigTemplate())
+	serverconfig.WriteConfigFile(appCfgFile, appCfg)
+	return nil
+}
+
+// loadAppConfig reads app.toml via viper and unmarshals into the app config struct.
+func loadAppConfig(configPath string) (*appConfig, error) {
+	v := viper.New()
+	v.SetConfigType("toml")
+	v.SetConfigName("app")
+	v.AddConfigPath(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+
+	cfg := &appConfig{}
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -2,6 +2,7 @@ package quickstart
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 
 	cmtcfg "github.com/cometbft/cometbft/config"
@@ -36,7 +37,7 @@ func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
 
 	// TX index retain-height follows min-retain-blocks (only when indexing is enabled)
 	if cfg.TxIndexing != TxIndexNull {
-		cmtCfg.TxIndex.RetainHeight = int64(cfg.MinRetainBlocks)
+		cmtCfg.TxIndex.RetainHeight = int64(min(cfg.MinRetainBlocks, uint64(math.MaxInt64))) //nolint:gosec // bounded by min()
 	} else {
 		cmtCfg.TxIndex.RetainHeight = 0
 	}

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -9,6 +9,7 @@ import (
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 
+	initiaapp "github.com/initia-labs/initia/app"
 	"github.com/initia-labs/initia/abcipp"
 	moveconfig "github.com/initia-labs/initia/x/move/config"
 
@@ -110,7 +111,27 @@ func applyAppToml(cfg QuickstartConfig, homeDir string) error {
 	return nil
 }
 
+// defaultAppConfig returns an appConfig initialized with the same defaults
+// that initiad init uses, so fields not modified by quickstart retain their values.
+func defaultAppConfig() *appConfig {
+	srvCfg := serverconfig.DefaultConfig()
+	srvCfg.MinGasPrices = fmt.Sprintf("0%s", initiaapp.BondDenom)
+	srvCfg.Mempool.MaxTxs = 2000
+	srvCfg.QueryGasLimit = 3000000
+	srvCfg.InterBlockCache = false
+
+	return &appConfig{
+		Config:     *srvCfg,
+		ABCIPP:     abcipp.DefaultAppConfig(),
+		MoveConfig: moveconfig.DefaultMoveConfig(),
+		Oracle:     oracleconfig.NewDefaultAppConfig(),
+		MemIAVL:    initiastorecfg.DefaultMemIAVLConfig(),
+		VersionDB:  initiastorecfg.DefaultVersionDBConfig(),
+	}
+}
+
 // loadAppConfig reads app.toml via viper and unmarshals into the app config struct.
+// Starts from initiad's default values so unset fields keep their defaults.
 func loadAppConfig(configPath string) (*appConfig, error) {
 	v := viper.New()
 	v.SetConfigType("toml")
@@ -121,7 +142,7 @@ func loadAppConfig(configPath string) (*appConfig, error) {
 		return nil, err
 	}
 
-	cfg := &appConfig{}
+	cfg := defaultAppConfig()
 	if err := v.Unmarshal(cfg); err != nil {
 		return nil, err
 	}

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -34,8 +34,12 @@ func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
 		cmtCfg.TxIndex.Indexer = "kv"
 	}
 
-	// TX index retain-height follows min-retain-blocks
-	cmtCfg.TxIndex.RetainHeight = int64(cfg.MinRetainBlocks)
+	// TX index retain-height follows min-retain-blocks (only when indexing is enabled)
+	if cfg.TxIndexing != TxIndexNull {
+		cmtCfg.TxIndex.RetainHeight = int64(cfg.MinRetainBlocks)
+	} else {
+		cmtCfg.TxIndex.RetainHeight = 0
+	}
 
 	cmtcfg.WriteConfigFile(configFile, cmtCfg)
 	return nil

--- a/cmd/initiad/quickstart/config.go
+++ b/cmd/initiad/quickstart/config.go
@@ -37,7 +37,7 @@ func applyConfigToml(cfg QuickstartConfig, homeDir string) error {
 
 	// TX index retain-height follows min-retain-blocks (only when indexing is enabled)
 	if cfg.TxIndexing != TxIndexNull {
-		cmtCfg.TxIndex.RetainHeight = int64(min(cfg.MinRetainBlocks, uint64(math.MaxInt64))) //nolint:gosec // bounded by min()
+		cmtCfg.TxIndex.RetainHeight = int64(min(cfg.MinRetainBlocks, uint64(math.MaxInt64))) //nolint:gosec
 	} else {
 		cmtCfg.TxIndex.RetainHeight = 0
 	}

--- a/cmd/initiad/quickstart/config_test.go
+++ b/cmd/initiad/quickstart/config_test.go
@@ -35,6 +35,9 @@ func setupTestConfigDir(t *testing.T) string {
 func TestApplyConfigToml(t *testing.T) {
 	tmpDir := setupTestConfigDir(t)
 
+	// Save original values before applying quickstart
+	origCfg := cmtcfg.DefaultConfig()
+
 	cfg := QuickstartConfig{
 		RPCAddress:      "tcp://0.0.0.0:26657",
 		TxIndexing:      TxIndexDefault,
@@ -44,7 +47,7 @@ func TestApplyConfigToml(t *testing.T) {
 	err := applyConfigToml(cfg, tmpDir)
 	require.NoError(t, err)
 
-	// Load back and verify
+	// Load back and verify changed fields
 	configPath := filepath.Join(tmpDir, "config")
 	loaded, err := loadCometConfig(configPath)
 	require.NoError(t, err)
@@ -52,6 +55,12 @@ func TestApplyConfigToml(t *testing.T) {
 	require.Equal(t, "tcp://0.0.0.0:26657", loaded.RPC.ListenAddress)
 	require.Equal(t, "kv", loaded.TxIndex.Indexer)
 	require.Equal(t, int64(500000), loaded.TxIndex.RetainHeight)
+
+	// Verify unchanged fields are preserved
+	require.Equal(t, origCfg.P2P.ListenAddress, loaded.P2P.ListenAddress)
+	require.Equal(t, origCfg.Consensus.TimeoutCommit, loaded.Consensus.TimeoutCommit)
+	require.Equal(t, origCfg.Mempool.Size, loaded.Mempool.Size)
+	require.Equal(t, origCfg.P2P.PersistentPeers, loaded.P2P.PersistentPeers)
 }
 
 func TestApplyConfigTomlNullIndex(t *testing.T) {
@@ -77,21 +86,24 @@ func TestApplyConfigTomlNullIndex(t *testing.T) {
 func TestApplyAppToml(t *testing.T) {
 	tmpDir := setupTestConfigDir(t)
 
+	// Save original values before applying quickstart
+	_, origCfg := appconfig.InitAppConfig()
+
 	cfg := QuickstartConfig{
-		Pruning:         PruningCustom,
+		Pruning:           PruningCustom,
 		PruningKeepRecent: "500",
 		PruningInterval:   "100",
-		MinRetainBlocks: 1000000,
-		TxIndexing:      TxIndexDefault,
-		TxIndexingKeys:  DefaultTxIndexingKeys,
-		APIAddress:      "tcp://0.0.0.0:1317",
-		MemIAVL:         true,
+		MinRetainBlocks:   1000000,
+		TxIndexing:        TxIndexDefault,
+		TxIndexingKeys:    DefaultTxIndexingKeys,
+		APIAddress:        "tcp://0.0.0.0:1317",
+		MemIAVL:           true,
 	}
 
 	err := applyAppToml(cfg, tmpDir)
 	require.NoError(t, err)
 
-	// Load back and verify
+	// Load back and verify changed fields
 	configPath := filepath.Join(tmpDir, "config")
 	loaded, err := loadAppConfig(configPath)
 	require.NoError(t, err)
@@ -104,6 +116,16 @@ func TestApplyAppToml(t *testing.T) {
 	require.Equal(t, "tcp://0.0.0.0:1317", loaded.API.Address)
 	require.True(t, loaded.MemIAVL.Enable)
 	require.Equal(t, DefaultTxIndexingKeys, loaded.IndexEvents)
+
+	// Verify unchanged fields are preserved
+	require.Equal(t, origCfg.MinGasPrices, loaded.MinGasPrices)
+	require.Equal(t, origCfg.Mempool.MaxTxs, loaded.Mempool.MaxTxs)
+	require.Equal(t, origCfg.QueryGasLimit, loaded.QueryGasLimit)
+	require.Equal(t, origCfg.GRPC.Enable, loaded.GRPC.Enable)
+	require.Equal(t, origCfg.GRPC.Address, loaded.GRPC.Address)
+	require.Equal(t, origCfg.GRPCWeb.Enable, loaded.GRPCWeb.Enable)
+	require.Equal(t, origCfg.API.RPCReadTimeout, loaded.API.RPCReadTimeout)
+	require.Equal(t, origCfg.API.MaxOpenConnections, loaded.API.MaxOpenConnections)
 }
 
 func TestApplyAppTomlDefaults(t *testing.T) {

--- a/cmd/initiad/quickstart/config_test.go
+++ b/cmd/initiad/quickstart/config_test.go
@@ -1,0 +1,132 @@
+package quickstart
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/stretchr/testify/require"
+
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/initia-labs/initia/cmd/initiad/appconfig"
+)
+
+func setupTestConfigDir(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+
+	// Create config.toml
+	tmCfg := cmtcfg.DefaultConfig()
+	tmCfg.SetRoot(tmpDir)
+	cmtcfg.WriteConfigFile(filepath.Join(configDir, "config.toml"), tmCfg)
+
+	// Create app.toml
+	template, appCfg := appconfig.InitAppConfig()
+	serverconfig.SetConfigTemplate(template)
+	serverconfig.WriteConfigFile(filepath.Join(configDir, "app.toml"), appCfg)
+
+	return tmpDir
+}
+
+func TestApplyConfigToml(t *testing.T) {
+	tmpDir := setupTestConfigDir(t)
+
+	cfg := QuickstartConfig{
+		RPCAddress:      "tcp://0.0.0.0:26657",
+		TxIndexing:      TxIndexDefault,
+		MinRetainBlocks: 500000,
+	}
+
+	err := applyConfigToml(cfg, tmpDir)
+	require.NoError(t, err)
+
+	// Load back and verify
+	configPath := filepath.Join(tmpDir, "config")
+	loaded, err := loadCometConfig(configPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "tcp://0.0.0.0:26657", loaded.RPC.ListenAddress)
+	require.Equal(t, "kv", loaded.TxIndex.Indexer)
+	require.Equal(t, int64(500000), loaded.TxIndex.RetainHeight)
+}
+
+func TestApplyConfigTomlNullIndex(t *testing.T) {
+	tmpDir := setupTestConfigDir(t)
+
+	cfg := QuickstartConfig{
+		RPCAddress:      "tcp://127.0.0.1:26657",
+		TxIndexing:      TxIndexNull,
+		MinRetainBlocks: 100000,
+	}
+
+	err := applyConfigToml(cfg, tmpDir)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tmpDir, "config")
+	loaded, err := loadCometConfig(configPath)
+	require.NoError(t, err)
+
+	require.Equal(t, "null", loaded.TxIndex.Indexer)
+	require.Equal(t, int64(0), loaded.TxIndex.RetainHeight)
+}
+
+func TestApplyAppToml(t *testing.T) {
+	tmpDir := setupTestConfigDir(t)
+
+	cfg := QuickstartConfig{
+		Pruning:         PruningCustom,
+		PruningKeepRecent: "500",
+		PruningInterval:   "100",
+		MinRetainBlocks: 1000000,
+		TxIndexing:      TxIndexDefault,
+		TxIndexingKeys:  DefaultTxIndexingKeys,
+		APIAddress:      "tcp://0.0.0.0:1317",
+		MemIAVL:         true,
+	}
+
+	err := applyAppToml(cfg, tmpDir)
+	require.NoError(t, err)
+
+	// Load back and verify
+	configPath := filepath.Join(tmpDir, "config")
+	loaded, err := loadAppConfig(configPath)
+	require.NoError(t, err)
+
+	require.Equal(t, PruningCustom, loaded.Pruning)
+	require.Equal(t, "500", loaded.PruningKeepRecent)
+	require.Equal(t, "100", loaded.PruningInterval)
+	require.Equal(t, uint64(1000000), loaded.MinRetainBlocks)
+	require.True(t, loaded.API.Enable)
+	require.Equal(t, "tcp://0.0.0.0:1317", loaded.API.Address)
+	require.True(t, loaded.MemIAVL.Enable)
+	require.Equal(t, DefaultTxIndexingKeys, loaded.IndexEvents)
+}
+
+func TestApplyAppTomlDefaults(t *testing.T) {
+	tmpDir := setupTestConfigDir(t)
+
+	cfg := QuickstartConfig{
+		Pruning:         PruningDefault,
+		MinRetainBlocks: 500000,
+		TxIndexing:      TxIndexNull,
+		MemIAVL:         false,
+	}
+
+	err := applyAppToml(cfg, tmpDir)
+	require.NoError(t, err)
+
+	configPath := filepath.Join(tmpDir, "config")
+	loaded, err := loadAppConfig(configPath)
+	require.NoError(t, err)
+
+	require.Equal(t, PruningDefault, loaded.Pruning)
+	require.Equal(t, "0", loaded.PruningKeepRecent)
+	require.Equal(t, "0", loaded.PruningInterval)
+	require.Equal(t, uint64(500000), loaded.MinRetainBlocks)
+	require.False(t, loaded.MemIAVL.Enable)
+	require.Empty(t, loaded.IndexEvents)
+}

--- a/cmd/initiad/quickstart/interactive.go
+++ b/cmd/initiad/quickstart/interactive.go
@@ -89,9 +89,10 @@ func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
 	cfg.TxIndexing = txIndexing
 
 	// 8. Custom indexing keys
-	if cfg.TxIndexing == TxIndexDefault {
+	switch cfg.TxIndexing {
+	case TxIndexDefault:
 		cfg.TxIndexingKeys = DefaultTxIndexingKeys
-	} else if cfg.TxIndexing == TxIndexCustom {
+	case TxIndexCustom:
 		keysStr, err := promptString(reader, cmd, "Enter indexing keys (comma-separated)", "")
 		if err != nil {
 			return cfg, err

--- a/cmd/initiad/quickstart/interactive.go
+++ b/cmd/initiad/quickstart/interactive.go
@@ -98,6 +98,9 @@ func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
 			return cfg, err
 		}
 		cfg.TxIndexingKeys = splitAndTrim(keysStr)
+		if len(cfg.TxIndexingKeys) == 0 {
+			return cfg, fmt.Errorf("tx indexing keys are required when using custom indexing")
+		}
 	}
 
 	// 9. MemIAVL (not compatible with snapshot sync)

--- a/cmd/initiad/quickstart/interactive.go
+++ b/cmd/initiad/quickstart/interactive.go
@@ -78,7 +78,11 @@ func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
 	cfg.MinRetainBlocks = minRetain
 
 	// 7. TX indexing
-	txIndexing, err := promptChoice(reader, cmd, "Select tx indexing", []string{TxIndexNull, TxIndexDefault, TxIndexCustom})
+	txIndexing, err := promptChoiceWithLabels(reader, cmd, "Select tx indexing", []choiceOption{
+		{Value: TxIndexNull, Label: "disable - no tx indexing"},
+		{Value: TxIndexDefault, Label: "default - IBC related keys (tx.height, tx.hash, packet sequences, etc.)"},
+		{Value: TxIndexCustom, Label: "custom - specify your own indexing keys"},
+	})
 	if err != nil {
 		return cfg, err
 	}
@@ -144,6 +148,32 @@ func promptChoice(reader *bufio.Reader, cmd *cobra.Command, prompt string, choic
 	}
 
 	return choices[idx-1], nil
+}
+
+type choiceOption struct {
+	Value string
+	Label string
+}
+
+func promptChoiceWithLabels(reader *bufio.Reader, cmd *cobra.Command, prompt string, choices []choiceOption) (string, error) {
+	cmd.Printf("\n%s:\n", prompt)
+	for i, c := range choices {
+		cmd.Printf("  %d) %s\n", i+1, c.Label)
+	}
+	cmd.Printf("Enter choice [1-%d]: ", len(choices))
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	input = strings.TrimSpace(input)
+
+	idx, err := strconv.Atoi(input)
+	if err != nil || idx < 1 || idx > len(choices) {
+		return "", fmt.Errorf("invalid choice: %s", input)
+	}
+
+	return choices[idx-1].Value, nil
 }
 
 func promptString(reader *bufio.Reader, cmd *cobra.Command, prompt, defaultVal string) (string, error) {

--- a/cmd/initiad/quickstart/interactive.go
+++ b/cmd/initiad/quickstart/interactive.go
@@ -99,12 +99,16 @@ func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
 		cfg.TxIndexingKeys = splitAndTrim(keysStr)
 	}
 
-	// 9. MemIAVL
-	memiavl, err := promptYesNo(reader, cmd, "Enable MemIAVL?")
-	if err != nil {
-		return cfg, err
+	// 9. MemIAVL (not compatible with snapshot sync)
+	if cfg.SyncMethod == SyncSnapshot {
+		cfg.MemIAVL = false
+	} else {
+		memiavl, err := promptYesNo(reader, cmd, "Enable MemIAVL?")
+		if err != nil {
+			return cfg, err
+		}
+		cfg.MemIAVL = memiavl
 	}
-	cfg.MemIAVL = memiavl
 
 	// 10. REST API
 	apiEnable, err := promptYesNo(reader, cmd, "Enable REST API?")

--- a/cmd/initiad/quickstart/interactive.go
+++ b/cmd/initiad/quickstart/interactive.go
@@ -1,0 +1,178 @@
+package quickstart
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func runInteractive(cmd *cobra.Command) (QuickstartConfig, error) {
+	reader := bufio.NewReader(cmd.InOrStdin())
+	var cfg QuickstartConfig
+
+	// 1. Network
+	network, err := promptChoice(reader, cmd, "Select network", []string{NetworkMainnet, NetworkTestnet})
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Network = network
+
+	// 2. Sync method
+	syncMethod, err := promptChoice(reader, cmd, "Select sync method", []string{SyncStateSync, SyncSnapshot})
+	if err != nil {
+		return cfg, err
+	}
+	cfg.SyncMethod = syncMethod
+
+	// 3. Snapshot URL
+	if cfg.SyncMethod == SyncSnapshot {
+		snapshotHint := "https://polkachu.com/tendermint_snapshots/initia"
+		if cfg.Network == NetworkTestnet {
+			snapshotHint = "https://www.polkachu.com/testnets/initia/snapshots"
+		}
+		cmd.Printf("  Find snapshots at: %s\n", snapshotHint)
+		url, err := promptString(reader, cmd, "Enter snapshot download URL", "")
+		if err != nil {
+			return cfg, err
+		}
+		if url == "" {
+			return cfg, fmt.Errorf("snapshot URL is required")
+		}
+		cfg.SnapshotURL = url
+	}
+
+	// 4. App state pruning
+	pruning, err := promptChoice(reader, cmd, "Select app state pruning", []string{PruningDefault, PruningNothing, PruningEverything, PruningCustom})
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Pruning = pruning
+
+	// 5. Custom pruning params
+	if cfg.Pruning == PruningCustom {
+		keepRecent, err := promptString(reader, cmd, "Keep recent states", "362880")
+		if err != nil {
+			return cfg, err
+		}
+		cfg.PruningKeepRecent = keepRecent
+
+		interval, err := promptString(reader, cmd, "Pruning interval", "100")
+		if err != nil {
+			return cfg, err
+		}
+		cfg.PruningInterval = interval
+	}
+
+	// 6. Min retain blocks
+	minRetainStr, err := promptString(reader, cmd, "Min retain blocks", fmt.Sprintf("%d", DefaultMinRetainBlocks))
+	if err != nil {
+		return cfg, err
+	}
+	minRetain, err := strconv.ParseUint(minRetainStr, 10, 64)
+	if err != nil {
+		return cfg, fmt.Errorf("invalid min-retain-blocks: %w", err)
+	}
+	cfg.MinRetainBlocks = minRetain
+
+	// 7. TX indexing
+	txIndexing, err := promptChoice(reader, cmd, "Select tx indexing", []string{TxIndexNull, TxIndexDefault, TxIndexCustom})
+	if err != nil {
+		return cfg, err
+	}
+	cfg.TxIndexing = txIndexing
+
+	// 8. Custom indexing keys
+	if cfg.TxIndexing == TxIndexDefault {
+		cfg.TxIndexingKeys = DefaultTxIndexingKeys
+	} else if cfg.TxIndexing == TxIndexCustom {
+		keysStr, err := promptString(reader, cmd, "Enter indexing keys (comma-separated)", "")
+		if err != nil {
+			return cfg, err
+		}
+		cfg.TxIndexingKeys = splitAndTrim(keysStr)
+	}
+
+	// 9. MemIAVL
+	memiavl, err := promptYesNo(reader, cmd, "Enable MemIAVL?")
+	if err != nil {
+		return cfg, err
+	}
+	cfg.MemIAVL = memiavl
+
+	// 10. REST API
+	apiEnable, err := promptYesNo(reader, cmd, "Enable REST API?")
+	if err != nil {
+		return cfg, err
+	}
+	if apiEnable {
+		apiAddr, err := promptString(reader, cmd, "API listen address", DefaultAPIAddress)
+		if err != nil {
+			return cfg, err
+		}
+		cfg.APIAddress = apiAddr
+	}
+
+	// 11. RPC address
+	rpcAddr, err := promptString(reader, cmd, "RPC listen address", DefaultRPCAddress)
+	if err != nil {
+		return cfg, err
+	}
+	cfg.RPCAddress = rpcAddr
+
+	return cfg, nil
+}
+
+func promptChoice(reader *bufio.Reader, cmd *cobra.Command, prompt string, choices []string) (string, error) {
+	cmd.Printf("\n%s:\n", prompt)
+	for i, c := range choices {
+		cmd.Printf("  %d) %s\n", i+1, c)
+	}
+	cmd.Printf("Enter choice [1-%d]: ", len(choices))
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	input = strings.TrimSpace(input)
+
+	idx, err := strconv.Atoi(input)
+	if err != nil || idx < 1 || idx > len(choices) {
+		return "", fmt.Errorf("invalid choice: %s", input)
+	}
+
+	return choices[idx-1], nil
+}
+
+func promptString(reader *bufio.Reader, cmd *cobra.Command, prompt, defaultVal string) (string, error) {
+	if defaultVal != "" {
+		cmd.Printf("%s [%s]: ", prompt, defaultVal)
+	} else {
+		cmd.Printf("%s: ", prompt)
+	}
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	input = strings.TrimSpace(input)
+
+	if input == "" {
+		return defaultVal, nil
+	}
+	return input, nil
+}
+
+func promptYesNo(reader *bufio.Reader, cmd *cobra.Command, prompt string) (bool, error) {
+	cmd.Printf("%s [y/n]: ", prompt)
+
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	return input == "y" || input == "yes", nil
+}

--- a/cmd/initiad/quickstart/interactive_test.go
+++ b/cmd/initiad/quickstart/interactive_test.go
@@ -1,0 +1,111 @@
+package quickstart
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptChoice(t *testing.T) {
+	input := "2\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	result, err := promptChoice(reader, cmd, "Pick one", []string{"a", "b", "c"})
+	require.NoError(t, err)
+	require.Equal(t, "b", result)
+}
+
+func TestPromptChoice_InvalidInput(t *testing.T) {
+	input := "abc\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	_, err := promptChoice(reader, cmd, "Pick one", []string{"a", "b", "c"})
+	require.Error(t, err)
+}
+
+func TestPromptChoice_OutOfRange(t *testing.T) {
+	input := "5\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	_, err := promptChoice(reader, cmd, "Pick one", []string{"a", "b", "c"})
+	require.Error(t, err)
+}
+
+func TestPromptString_WithDefault(t *testing.T) {
+	input := "\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	result, err := promptString(reader, cmd, "Enter value", "mydefault")
+	require.NoError(t, err)
+	require.Equal(t, "mydefault", result)
+}
+
+func TestPromptString_WithInput(t *testing.T) {
+	input := "custom_value\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	result, err := promptString(reader, cmd, "Enter value", "mydefault")
+	require.NoError(t, err)
+	require.Equal(t, "custom_value", result)
+}
+
+func TestPromptYesNo_Yes(t *testing.T) {
+	input := "y\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	result, err := promptYesNo(reader, cmd, "Continue?")
+	require.NoError(t, err)
+	require.True(t, result)
+}
+
+func TestPromptYesNo_No(t *testing.T) {
+	input := "n\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	result, err := promptYesNo(reader, cmd, "Continue?")
+	require.NoError(t, err)
+	require.False(t, result)
+}
+
+func TestPromptChoiceWithLabels(t *testing.T) {
+	input := "1\n"
+	reader := bufio.NewReader(strings.NewReader(input))
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	choices := []choiceOption{
+		{Value: "val1", Label: "Label One"},
+		{Value: "val2", Label: "Label Two"},
+		{Value: "val3", Label: "Label Three"},
+	}
+
+	result, err := promptChoiceWithLabels(reader, cmd, "Pick one", choices)
+	require.NoError(t, err)
+	require.Equal(t, "val1", result)
+}

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -27,7 +27,11 @@ var rpcEndpoints = map[string]string{
 func downloadGenesis(network, homeDir string) error {
 	pc := providers.Polkachu[network]
 	destPath := filepath.Join(homeDir, "config", "genesis.json")
-	return providers.DownloadFile(pc.GenesisURL, destPath)
+	if err := providers.DownloadFile(pc.GenesisURL, destPath); err != nil {
+		fmt.Printf("Pre-built genesis download failed (%v), fetching from RPC...\n", err)
+		return downloadGenesisFromRPC(rpcEndpoints[network], destPath)
+	}
+	return nil
 }
 
 func downloadAddrbook(network, homeDir string) error {
@@ -94,6 +98,36 @@ func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, stateSync
 
 	cmtcfg.WriteConfigFile(configFile, cfg)
 	return nil
+}
+
+// downloadGenesisFromRPC fetches genesis.json from the RPC /genesis endpoint.
+// The response wraps genesis in {"result":{"genesis":{...}}}, so we extract the inner object.
+func downloadGenesisFromRPC(rpcURL, destPath string) error {
+	resp, err := providers.HTTPClient.Get(rpcURL + "/genesis")
+	if err != nil {
+		return fmt.Errorf("failed to fetch genesis from RPC: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("RPC %s/genesis returned status %d", rpcURL, resp.StatusCode)
+	}
+
+	var result struct {
+		Result struct {
+			Genesis json.RawMessage `json:"genesis"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 500<<20)).Decode(&result); err != nil {
+		return fmt.Errorf("failed to decode genesis response: %w", err)
+	}
+
+	if len(result.Result.Genesis) == 0 {
+		return fmt.Errorf("RPC returned empty genesis")
+	}
+
+	return providers.WriteAtomically(destPath, strings.NewReader(string(result.Result.Genesis)))
 }
 
 // buildAddrbookFromRPC fetches peers from the RPC node's /net_info and builds

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -162,7 +162,11 @@ func fetchNetInfoPeerAddrs(rpcURL string) ([]*p2p.NetAddress, error) {
 		if err != nil {
 			continue
 		}
-		addr := p2p.NewNetAddressIPPort(net.ParseIP(peer.RemoteIP), port)
+		ip := net.ParseIP(peer.RemoteIP)
+		if ip == nil {
+			continue
+		}
+		addr := p2p.NewNetAddressIPPort(ip, port)
 		addr.ID = p2p.ID(peer.NodeInfo.ID)
 		addrs = append(addrs, addr)
 	}

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -149,10 +149,15 @@ func buildAddrbookFromRPC(rpcURL, destPath string) error {
 	book := pex.NewAddrBook(destPath, false)
 	book.SetLogger(log.NewNopLogger())
 
+	added := 0
 	for _, addr := range peerAddrs {
 		if err := book.AddAddress(addr, srcAddr); err != nil {
 			continue
 		}
+		added++
+	}
+	if added == 0 {
+		return fmt.Errorf("RPC %s/net_info returned no usable peers", rpcURL)
 	}
 
 	book.Save()

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -103,10 +103,7 @@ func setupStateSync(network, homeDir string) error {
 		return fmt.Errorf("failed to fetch latest height: %w", err)
 	}
 
-	trustHeight := latestHeight - 2000
-	if trustHeight < 1 {
-		trustHeight = 1
-	}
+	trustHeight := max(latestHeight-2000, 1)
 
 	trustHash, err := fetchBlockHash(nc.StateSyncRPC, trustHeight)
 	if err != nil {
@@ -116,15 +113,15 @@ func setupStateSync(network, homeDir string) error {
 		return fmt.Errorf("RPC returned empty block hash for height %d; the block may have been pruned", trustHeight)
 	}
 
-	polkachuPeer, err := fetchPolkachuPeer(nc.LivePeersAPI)
+	stateSyncPeer, err := fetchStateSyncPeer(nc.LivePeersAPI)
 	if err != nil {
-		return fmt.Errorf("failed to fetch polkachu peer: %w", err)
+		return fmt.Errorf("failed to fetch state sync peer: %w", err)
 	}
-	if polkachuPeer == "" {
-		return fmt.Errorf("polkachu API returned empty peer")
+	if stateSyncPeer == "" {
+		return fmt.Errorf("API returned empty state sync peer")
 	}
 
-	return applyStateSync(homeDir, nc.StateSyncRPC, trustHeight, trustHash, polkachuPeer)
+	return applyStateSync(homeDir, nc.StateSyncRPC, trustHeight, trustHash, stateSyncPeer)
 }
 
 func fetchLatestHeight(rpc string) (int64, error) {
@@ -183,10 +180,10 @@ func fetchBlockHash(rpc string, height int64) (string, error) {
 }
 
 type livePeersResponse struct {
-	PolkachuPeer string `json:"polkachu_peer"`
+	StateSyncPeer string `json:"polkachu_peer"`
 }
 
-func fetchPolkachuPeer(apiURL string) (string, error) {
+func fetchStateSyncPeer(apiURL string) (string, error) {
 	resp, err := httpClient.Get(apiURL)
 	if err != nil {
 		return "", err
@@ -202,12 +199,12 @@ func fetchPolkachuPeer(apiURL string) (string, error) {
 		return "", err
 	}
 
-	return result.PolkachuPeer, nil
+	return result.StateSyncPeer, nil
 }
 
 // applyStateSync loads config.toml via viper, modifies statesync/p2p fields,
 // then writes back using CometBFT's WriteConfigFile to preserve comments and formatting.
-func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, polkachuPeer string) error {
+func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, stateSyncPeer string) error {
 	configPath := filepath.Join(homeDir, "config")
 	configFile := filepath.Join(configPath, "config.toml")
 
@@ -223,20 +220,18 @@ func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, polkachuP
 	cfg.StateSync.TrustHeight = trustHeight
 	cfg.StateSync.TrustHash = trustHash
 
-	// Append polkachu peer to persistent_peers if not already present
-	if !strings.Contains(cfg.P2P.PersistentPeers, polkachuPeer) {
+	// Append state sync peer to persistent_peers if not already present
+	if !strings.Contains(cfg.P2P.PersistentPeers, stateSyncPeer) {
 		if cfg.P2P.PersistentPeers != "" {
 			cfg.P2P.PersistentPeers += ","
 		}
-		cfg.P2P.PersistentPeers += polkachuPeer
+		cfg.P2P.PersistentPeers += stateSyncPeer
 	}
 
 	// Write back using CometBFT template to preserve comments
 	cmtcfg.WriteConfigFile(configFile, cfg)
 	return nil
 }
-
-
 
 // buildAddrbookFromRPC fetches peers from the RPC node's /net_info and builds
 // addrbook.json using CometBFT's pex.AddrBook API.

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -8,9 +8,15 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/spf13/viper"
 )
+
+var httpClient = &http.Client{
+	Timeout: 60 * time.Second,
+}
 
 type networkConfig struct {
 	GenesisURL   string
@@ -47,7 +53,7 @@ func downloadAddrbook(network, homeDir string) error {
 }
 
 func downloadFile(url, destPath string) error {
-	resp, err := http.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return fmt.Errorf("failed to download %s: %w", url, err)
 	}
@@ -57,14 +63,23 @@ func downloadFile(url, destPath string) error {
 		return fmt.Errorf("failed to download %s: status %d", url, resp.StatusCode)
 	}
 
-	out, err := os.Create(destPath)
+	// Write to temp file and rename atomically to avoid corrupt files on failure
+	tmpPath := destPath + ".tmp"
+	out, err := os.Create(tmpPath)
 	if err != nil {
-		return fmt.Errorf("failed to create %s: %w", destPath, err)
+		return fmt.Errorf("failed to create %s: %w", tmpPath, err)
 	}
-	defer out.Close()
+	defer os.Remove(tmpPath)
 
-	_, err = io.Copy(out, resp.Body)
-	return err
+	if _, err = io.Copy(out, resp.Body); err != nil {
+		out.Close()
+		return fmt.Errorf("failed to write %s: %w", destPath, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close %s: %w", destPath, err)
+	}
+
+	return os.Rename(tmpPath, destPath)
 }
 
 func setupStateSync(network, homeDir string) error {
@@ -76,26 +91,39 @@ func setupStateSync(network, homeDir string) error {
 	}
 
 	trustHeight := latestHeight - 2000
+	if trustHeight < 1 {
+		trustHeight = 1
+	}
 
 	trustHash, err := fetchBlockHash(nc.StateSyncRPC, trustHeight)
 	if err != nil {
 		return fmt.Errorf("failed to fetch trust hash: %w", err)
+	}
+	if trustHash == "" {
+		return fmt.Errorf("RPC returned empty block hash for height %d; the block may have been pruned", trustHeight)
 	}
 
 	polkachuPeer, err := fetchPolkachuPeer(nc.LivePeersAPI)
 	if err != nil {
 		return fmt.Errorf("failed to fetch polkachu peer: %w", err)
 	}
+	if polkachuPeer == "" {
+		return fmt.Errorf("polkachu API returned empty peer")
+	}
 
 	return applyStateSync(homeDir, nc.StateSyncRPC, trustHeight, trustHash, polkachuPeer)
 }
 
 func fetchLatestHeight(rpc string) (int64, error) {
-	resp, err := http.Get(rpc + "/abci_info")
+	resp, err := httpClient.Get(rpc + "/abci_info")
 	if err != nil {
 		return 0, err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("RPC %s/abci_info returned status %d", rpc, resp.StatusCode)
+	}
 
 	var result struct {
 		Result struct {
@@ -105,7 +133,7 @@ func fetchLatestHeight(rpc string) (int64, error) {
 		} `json:"result"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
 		return 0, err
 	}
 
@@ -116,11 +144,15 @@ func fetchLatestHeight(rpc string) (int64, error) {
 
 func fetchBlockHash(rpc string, height int64) (string, error) {
 	url := fmt.Sprintf("%s/block?height=%d", rpc, height)
-	resp, err := http.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("RPC %s returned status %d", url, resp.StatusCode)
+	}
 
 	var result struct {
 		Result struct {
@@ -130,7 +162,7 @@ func fetchBlockHash(rpc string, height int64) (string, error) {
 		} `json:"result"`
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
 		return "", err
 	}
 
@@ -142,42 +174,71 @@ type livePeersResponse struct {
 }
 
 func fetchPolkachuPeer(apiURL string) (string, error) {
-	resp, err := http.Get(apiURL)
+	resp, err := httpClient.Get(apiURL)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API %s returned status %d", apiURL, resp.StatusCode)
+	}
+
 	var result livePeersResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
 		return "", err
 	}
 
 	return result.PolkachuPeer, nil
 }
 
+// applyStateSync loads config.toml via viper, modifies statesync/p2p fields,
+// then writes back using CometBFT's WriteConfigFile to preserve comments and formatting.
 func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, polkachuPeer string) error {
-	configPath := filepath.Join(homeDir, "config", "config.toml")
+	configPath := filepath.Join(homeDir, "config")
+	configFile := filepath.Join(configPath, "config.toml")
 
-	vpr := viper.New()
-	vpr.SetConfigFile(configPath)
-	if err := vpr.ReadInConfig(); err != nil {
-		return fmt.Errorf("failed to read config.toml: %w", err)
+	// Load config via viper and unmarshal into CometBFT config struct
+	cfg, err := loadCometConfig(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config.toml: %w", err)
 	}
 
-	vpr.Set("statesync.enable", true)
-	vpr.Set("statesync.rpc_servers", rpc+","+rpc)
-	vpr.Set("statesync.trust_height", trustHeight)
-	vpr.Set("statesync.trust_hash", trustHash)
+	// Set statesync config
+	cfg.StateSync.Enable = true
+	cfg.StateSync.RPCServers = []string{rpc, rpc}
+	cfg.StateSync.TrustHeight = trustHeight
+	cfg.StateSync.TrustHash = trustHash
 
-	existingPeers := vpr.GetString("p2p.persistent_peers")
-	if !strings.Contains(existingPeers, polkachuPeer) {
-		if existingPeers != "" {
-			existingPeers += ","
+	// Append polkachu peer to persistent_peers if not already present
+	if !strings.Contains(cfg.P2P.PersistentPeers, polkachuPeer) {
+		if cfg.P2P.PersistentPeers != "" {
+			cfg.P2P.PersistentPeers += ","
 		}
-		existingPeers += polkachuPeer
-		vpr.Set("p2p.persistent_peers", existingPeers)
+		cfg.P2P.PersistentPeers += polkachuPeer
 	}
 
-	return vpr.WriteConfig()
+	// Write back using CometBFT template to preserve comments
+	cmtcfg.WriteConfigFile(configFile, cfg)
+	return nil
+}
+
+// loadCometConfig reads config.toml via viper and unmarshals into a CometBFT Config struct.
+func loadCometConfig(configPath string) (*cmtcfg.Config, error) {
+	v := viper.New()
+	v.SetConfigType("toml")
+	v.SetConfigName("config")
+	v.AddConfigPath(configPath)
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, err
+	}
+
+	cfg := cmtcfg.DefaultConfig()
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, err
+	}
+
+	cfg.SetRoot(filepath.Dir(configPath))
+	return cfg, nil
 }

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -239,4 +239,3 @@ func parsePortFromListenAddr(listenAddr string) (uint16, error) {
 
 	return uint16(port), nil
 }
-

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -1,12 +1,17 @@
 package quickstart
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +28,7 @@ type networkConfig struct {
 	AddrbookURL  string
 	StateSyncRPC string
 	LivePeersAPI string
+	RPCURL       string // public RPC endpoint for fallback addrbook generation
 }
 
 var networks = map[string]networkConfig{
@@ -31,12 +37,14 @@ var networks = map[string]networkConfig{
 		AddrbookURL:  "https://snapshots.polkachu.com/addrbook/initia/addrbook.json",
 		StateSyncRPC: "https://initia-rpc.polkachu.com:443",
 		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia/live_peers",
+		RPCURL:       "https://rpc.initia.xyz",
 	},
 	NetworkTestnet: {
 		GenesisURL:   "https://snapshots.polkachu.com/testnet-genesis/initia/genesis.json",
 		AddrbookURL:  "https://snapshots.polkachu.com/testnet-addrbook/initia/addrbook.json",
 		StateSyncRPC: "https://initia-testnet-rpc.polkachu.com:443",
 		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia-testnet/live_peers",
+		RPCURL:       "https://rpc.testnet.initia.xyz",
 	},
 }
 
@@ -49,7 +57,11 @@ func downloadGenesis(network, homeDir string) error {
 func downloadAddrbook(network, homeDir string) error {
 	nc := networks[network]
 	destPath := filepath.Join(homeDir, "config", "addrbook.json")
-	return downloadFile(nc.AddrbookURL, destPath)
+	if err := downloadFile(nc.AddrbookURL, destPath); err != nil {
+		fmt.Printf("Pre-built addrbook download failed (%v), building from RPC peers...\n", err)
+		return buildAddrbookFromRPC(nc.RPCURL, destPath)
+	}
+	return nil
 }
 
 func downloadFile(url, destPath string) error {
@@ -241,4 +253,233 @@ func loadCometConfig(configPath string) (*cmtcfg.Config, error) {
 
 	cfg.SetRoot(filepath.Dir(configPath))
 	return cfg, nil
+}
+
+// ── Fallback addrbook generation from RPC ──────────────────────────────────────
+//
+// When the pre-built addrbook download fails, we reconstruct addrbook.json by
+// querying the public RPC node's /net_info (peer list) and /status (node identity).
+//
+// CometBFT addrbook format notes:
+//   - "key": a random 20-byte hex string used internally for bucket hashing.
+//     We generate a fresh random one; CometBFT accepts any valid hex string.
+//   - "addr": the peer's reachable address. We use remote_ip from net_info
+//     combined with the port parsed from node_info.listen_addr.
+//   - "src": the node that told us about this peer (the RPC node itself).
+//     We use result.node_info.id from /status and resolve the RPC hostname to get the IP.
+//   - "bucket_type": 1 = "new" bucket (peers we haven't connected to yet).
+//   - "buckets": [0] is a valid assignment; CometBFT rehashes on load.
+//   - "last_attempt": set to current time to indicate freshly discovered peers.
+//   - "last_success" / "last_ban_time": zero time.
+
+// addrBook is the top-level CometBFT address book structure.
+type addrBook struct {
+	Key   string          `json:"key"`
+	Addrs []addrBookEntry `json:"addrs"`
+}
+
+// addrBookEntry represents a single peer entry in the address book.
+type addrBookEntry struct {
+	Addr        netAddress `json:"addr"`
+	Src         netAddress `json:"src"`
+	Buckets     []int      `json:"buckets"`
+	Attempts    int        `json:"attempts"`
+	BucketType  int        `json:"bucket_type"`
+	LastAttempt time.Time  `json:"last_attempt"`
+	LastSuccess time.Time  `json:"last_success"`
+	LastBanTime time.Time  `json:"last_ban_time"`
+}
+
+// netAddress is a CometBFT network address (node ID + IP + port).
+type netAddress struct {
+	ID   string `json:"id"`
+	IP   string `json:"ip"`
+	Port uint16 `json:"port"`
+}
+
+// buildAddrbookFromRPC fetches peers from the RPC node and writes addrbook.json.
+func buildAddrbookFromRPC(rpcURL, destPath string) error {
+	// Fetch peers from /net_info
+	peers, err := fetchNetInfoPeers(rpcURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch net_info: %w", err)
+	}
+	if len(peers) == 0 {
+		return fmt.Errorf("RPC %s/net_info returned no peers", rpcURL)
+	}
+
+	// Fetch RPC node identity for the "src" field
+	src, err := fetchRPCNodeAddress(rpcURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch RPC node status: %w", err)
+	}
+
+	// Generate random 20-byte key
+	keyBytes := make([]byte, 20)
+	if _, err := rand.Read(keyBytes); err != nil {
+		return fmt.Errorf("failed to generate addrbook key: %w", err)
+	}
+
+	now := time.Now()
+	zeroTime := time.Time{}
+
+	book := addrBook{
+		Key:   hex.EncodeToString(keyBytes),
+		Addrs: make([]addrBookEntry, 0, len(peers)),
+	}
+
+	for _, p := range peers {
+		book.Addrs = append(book.Addrs, addrBookEntry{
+			Addr:        p,
+			Src:         src,
+			Buckets:     []int{0},
+			Attempts:    0,
+			BucketType:  1,
+			LastAttempt: now,
+			LastSuccess: zeroTime,
+			LastBanTime: zeroTime,
+		})
+	}
+
+	data, err := json.MarshalIndent(book, "", "    ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal addrbook: %w", err)
+	}
+
+	// Write atomically via temp file
+	tmpPath := destPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write %s: %w", tmpPath, err)
+	}
+	defer os.Remove(tmpPath)
+
+	return os.Rename(tmpPath, destPath)
+}
+
+// fetchNetInfoPeers calls /net_info and returns parsed peer addresses.
+func fetchNetInfoPeers(rpcURL string) ([]netAddress, error) {
+	resp, err := httpClient.Get(rpcURL + "/net_info")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s/net_info returned status %d", rpcURL, resp.StatusCode)
+	}
+
+	var result struct {
+		Result struct {
+			Peers []struct {
+				NodeInfo struct {
+					ID         string `json:"id"`
+					ListenAddr string `json:"listen_addr"`
+				} `json:"node_info"`
+				RemoteIP string `json:"remote_ip"`
+			} `json:"peers"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&result); err != nil {
+		return nil, err
+	}
+
+	addrs := make([]netAddress, 0, len(result.Result.Peers))
+	for _, p := range result.Result.Peers {
+		port, err := parsePortFromListenAddr(p.NodeInfo.ListenAddr)
+		if err != nil {
+			// Skip peers with unparseable listen addresses
+			continue
+		}
+		if p.RemoteIP == "" || p.NodeInfo.ID == "" {
+			continue
+		}
+		addrs = append(addrs, netAddress{
+			ID:   p.NodeInfo.ID,
+			IP:   p.RemoteIP,
+			Port: port,
+		})
+	}
+
+	return addrs, nil
+}
+
+// fetchRPCNodeAddress calls /status and resolves the RPC hostname to build
+// the "src" address for addrbook entries.
+func fetchRPCNodeAddress(rpcURL string) (netAddress, error) {
+	// Fetch node ID and listen port from /status
+	resp, err := httpClient.Get(rpcURL + "/status")
+	if err != nil {
+		return netAddress{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return netAddress{}, fmt.Errorf("%s/status returned status %d", rpcURL, resp.StatusCode)
+	}
+
+	var result struct {
+		Result struct {
+			NodeInfo struct {
+				ID         string `json:"id"`
+				ListenAddr string `json:"listen_addr"`
+			} `json:"node_info"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
+		return netAddress{}, err
+	}
+
+	port, err := parsePortFromListenAddr(result.Result.NodeInfo.ListenAddr)
+	if err != nil {
+		port = 26656 // default CometBFT P2P port
+	}
+
+	// Resolve the RPC URL hostname to get the IP for the src field
+	parsed, err := url.Parse(rpcURL)
+	if err != nil {
+		return netAddress{}, fmt.Errorf("failed to parse RPC URL %q: %w", rpcURL, err)
+	}
+
+	host := parsed.Hostname()
+	ip := host // fallback: use the hostname directly if it's already an IP
+	if net.ParseIP(host) == nil {
+		// It's a hostname, resolve it
+		ips, err := net.LookupHost(host)
+		if err != nil || len(ips) == 0 {
+			// If DNS resolution fails, use the hostname as-is
+			ip = host
+		} else {
+			ip = ips[0]
+		}
+	}
+
+	return netAddress{
+		ID:   result.Result.NodeInfo.ID,
+		IP:   ip,
+		Port: port,
+	}, nil
+}
+
+// parsePortFromListenAddr extracts the port number from a CometBFT listen address
+// like "tcp://0.0.0.0:26656" or "0.0.0.0:26656".
+func parsePortFromListenAddr(listenAddr string) (uint16, error) {
+	// Strip protocol prefix if present
+	addr := listenAddr
+	if idx := strings.Index(addr, "://"); idx >= 0 {
+		addr = addr[idx+3:]
+	}
+
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse listen_addr %q: %w", listenAddr, err)
+	}
+
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port in listen_addr %q: %w", listenAddr, err)
+	}
+
+	return uint16(port), nil
 }

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	cmtcfg "github.com/cometbft/cometbft/config"
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 )
 
@@ -247,7 +248,9 @@ func loadCometConfig(configPath string) (*cmtcfg.Config, error) {
 	}
 
 	cfg := cmtcfg.DefaultConfig()
-	if err := v.Unmarshal(cfg); err != nil {
+	if err := v.Unmarshal(cfg, func(dc *mapstructure.DecoderConfig) {
+		dc.Squash = true
+	}); err != nil {
 		return nil, err
 	}
 

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -1,8 +1,6 @@
 package quickstart
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,8 +14,9 @@ import (
 	"time"
 
 	cmtcfg "github.com/cometbft/cometbft/config"
-	"github.com/mitchellh/mapstructure"
-	"github.com/spf13/viper"
+	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cometbft/cometbft/p2p"
+	"github.com/cometbft/cometbft/p2p/pex"
 )
 
 var httpClient = &http.Client{
@@ -84,7 +83,8 @@ func downloadFile(url, destPath string) error {
 	}
 	defer os.Remove(tmpPath)
 
-	if _, err = io.Copy(out, resp.Body); err != nil {
+	// Limit download to 500MB to prevent disk exhaustion
+	if _, err = io.Copy(out, io.LimitReader(resp.Body, 500<<20)); err != nil {
 		out.Close()
 		return fmt.Errorf("failed to write %s: %w", destPath, err)
 	}
@@ -236,131 +236,43 @@ func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, polkachuP
 	return nil
 }
 
-// loadCometConfig reads config.toml via viper and unmarshals into a CometBFT Config struct.
-func loadCometConfig(configPath string) (*cmtcfg.Config, error) {
-	v := viper.New()
-	v.SetConfigType("toml")
-	v.SetConfigName("config")
-	v.AddConfigPath(configPath)
 
-	if err := v.ReadInConfig(); err != nil {
-		return nil, err
-	}
 
-	cfg := cmtcfg.DefaultConfig()
-	if err := v.Unmarshal(cfg, func(dc *mapstructure.DecoderConfig) {
-		dc.Squash = true
-	}); err != nil {
-		return nil, err
-	}
-
-	cfg.SetRoot(filepath.Dir(configPath))
-	return cfg, nil
-}
-
-// ── Fallback addrbook generation from RPC ──────────────────────────────────────
-//
-// When the pre-built addrbook download fails, we reconstruct addrbook.json by
-// querying the public RPC node's /net_info (peer list) and /status (node identity).
-//
-// CometBFT addrbook format notes:
-//   - "key": a random 20-byte hex string used internally for bucket hashing.
-//     We generate a fresh random one; CometBFT accepts any valid hex string.
-//   - "addr": the peer's reachable address. We use remote_ip from net_info
-//     combined with the port parsed from node_info.listen_addr.
-//   - "src": the node that told us about this peer (the RPC node itself).
-//     We use result.node_info.id from /status and resolve the RPC hostname to get the IP.
-//   - "bucket_type": 1 = "new" bucket (peers we haven't connected to yet).
-//   - "buckets": [0] is a valid assignment; CometBFT rehashes on load.
-//   - "last_attempt": set to current time to indicate freshly discovered peers.
-//   - "last_success" / "last_ban_time": zero time.
-
-// addrBook is the top-level CometBFT address book structure.
-type addrBook struct {
-	Key   string          `json:"key"`
-	Addrs []addrBookEntry `json:"addrs"`
-}
-
-// addrBookEntry represents a single peer entry in the address book.
-type addrBookEntry struct {
-	Addr        netAddress `json:"addr"`
-	Src         netAddress `json:"src"`
-	Buckets     []int      `json:"buckets"`
-	Attempts    int        `json:"attempts"`
-	BucketType  int        `json:"bucket_type"`
-	LastAttempt time.Time  `json:"last_attempt"`
-	LastSuccess time.Time  `json:"last_success"`
-	LastBanTime time.Time  `json:"last_ban_time"`
-}
-
-// netAddress is a CometBFT network address (node ID + IP + port).
-type netAddress struct {
-	ID   string `json:"id"`
-	IP   string `json:"ip"`
-	Port uint16 `json:"port"`
-}
-
-// buildAddrbookFromRPC fetches peers from the RPC node and writes addrbook.json.
+// buildAddrbookFromRPC fetches peers from the RPC node's /net_info and builds
+// addrbook.json using CometBFT's pex.AddrBook API.
 func buildAddrbookFromRPC(rpcURL, destPath string) error {
-	// Fetch peers from /net_info
-	peers, err := fetchNetInfoPeers(rpcURL)
+	// Fetch peer addresses from /net_info
+	peerAddrs, err := fetchNetInfoPeerAddrs(rpcURL)
 	if err != nil {
 		return fmt.Errorf("failed to fetch net_info: %w", err)
 	}
-	if len(peers) == 0 {
+	if len(peerAddrs) == 0 {
 		return fmt.Errorf("RPC %s/net_info returned no peers", rpcURL)
 	}
 
-	// Fetch RPC node identity for the "src" field
-	src, err := fetchRPCNodeAddress(rpcURL)
+	// Fetch RPC node address for the "src" field
+	srcAddr, err := fetchRPCNodeAddr(rpcURL)
 	if err != nil {
 		return fmt.Errorf("failed to fetch RPC node status: %w", err)
 	}
 
-	// Generate random 20-byte key
-	keyBytes := make([]byte, 20)
-	if _, err := rand.Read(keyBytes); err != nil {
-		return fmt.Errorf("failed to generate addrbook key: %w", err)
+	// Create addrbook using CometBFT's pex API
+	book := pex.NewAddrBook(destPath, false)
+	book.SetLogger(log.NewNopLogger())
+
+	for _, addr := range peerAddrs {
+		if err := book.AddAddress(addr, srcAddr); err != nil {
+			// Skip peers that fail validation (e.g., non-routable IPs)
+			continue
+		}
 	}
 
-	now := time.Now()
-	zeroTime := time.Time{}
-
-	book := addrBook{
-		Key:   hex.EncodeToString(keyBytes),
-		Addrs: make([]addrBookEntry, 0, len(peers)),
-	}
-
-	for _, p := range peers {
-		book.Addrs = append(book.Addrs, addrBookEntry{
-			Addr:        p,
-			Src:         src,
-			Buckets:     []int{0},
-			Attempts:    0,
-			BucketType:  1,
-			LastAttempt: now,
-			LastSuccess: zeroTime,
-			LastBanTime: zeroTime,
-		})
-	}
-
-	data, err := json.MarshalIndent(book, "", "    ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal addrbook: %w", err)
-	}
-
-	// Write atomically via temp file
-	tmpPath := destPath + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", tmpPath, err)
-	}
-	defer os.Remove(tmpPath)
-
-	return os.Rename(tmpPath, destPath)
+	book.Save()
+	return nil
 }
 
-// fetchNetInfoPeers calls /net_info and returns parsed peer addresses.
-func fetchNetInfoPeers(rpcURL string) ([]netAddress, error) {
+// fetchNetInfoPeerAddrs calls /net_info and returns parsed p2p.NetAddress entries.
+func fetchNetInfoPeerAddrs(rpcURL string) ([]*p2p.NetAddress, error) {
 	resp, err := httpClient.Get(rpcURL + "/net_info")
 	if err != nil {
 		return nil, err
@@ -387,38 +299,34 @@ func fetchNetInfoPeers(rpcURL string) ([]netAddress, error) {
 		return nil, err
 	}
 
-	addrs := make([]netAddress, 0, len(result.Result.Peers))
-	for _, p := range result.Result.Peers {
-		port, err := parsePortFromListenAddr(p.NodeInfo.ListenAddr)
+	addrs := make([]*p2p.NetAddress, 0, len(result.Result.Peers))
+	for _, peer := range result.Result.Peers {
+		if peer.RemoteIP == "" || peer.NodeInfo.ID == "" {
+			continue
+		}
+		port, err := parsePortFromListenAddr(peer.NodeInfo.ListenAddr)
 		if err != nil {
-			// Skip peers with unparseable listen addresses
 			continue
 		}
-		if p.RemoteIP == "" || p.NodeInfo.ID == "" {
-			continue
-		}
-		addrs = append(addrs, netAddress{
-			ID:   p.NodeInfo.ID,
-			IP:   p.RemoteIP,
-			Port: port,
-		})
+		addr := p2p.NewNetAddressIPPort(net.ParseIP(peer.RemoteIP), port)
+		addr.ID = p2p.ID(peer.NodeInfo.ID)
+		addrs = append(addrs, addr)
 	}
 
 	return addrs, nil
 }
 
-// fetchRPCNodeAddress calls /status and resolves the RPC hostname to build
-// the "src" address for addrbook entries.
-func fetchRPCNodeAddress(rpcURL string) (netAddress, error) {
-	// Fetch node ID and listen port from /status
+// fetchRPCNodeAddr calls /status and resolves the RPC hostname to build
+// the source p2p.NetAddress for addrbook entries.
+func fetchRPCNodeAddr(rpcURL string) (*p2p.NetAddress, error) {
 	resp, err := httpClient.Get(rpcURL + "/status")
 	if err != nil {
-		return netAddress{}, err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return netAddress{}, fmt.Errorf("%s/status returned status %d", rpcURL, resp.StatusCode)
+		return nil, fmt.Errorf("%s/status returned status %d", rpcURL, resp.StatusCode)
 	}
 
 	var result struct {
@@ -431,44 +339,38 @@ func fetchRPCNodeAddress(rpcURL string) (netAddress, error) {
 	}
 
 	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
-		return netAddress{}, err
+		return nil, err
 	}
 
 	port, err := parsePortFromListenAddr(result.Result.NodeInfo.ListenAddr)
 	if err != nil {
-		port = 26656 // default CometBFT P2P port
+		port = 26656
 	}
 
-	// Resolve the RPC URL hostname to get the IP for the src field
+	// Resolve the RPC URL hostname to get the IP
 	parsed, err := url.Parse(rpcURL)
 	if err != nil {
-		return netAddress{}, fmt.Errorf("failed to parse RPC URL %q: %w", rpcURL, err)
+		return nil, fmt.Errorf("failed to parse RPC URL %q: %w", rpcURL, err)
 	}
 
 	host := parsed.Hostname()
-	ip := host // fallback: use the hostname directly if it's already an IP
-	if net.ParseIP(host) == nil {
-		// It's a hostname, resolve it
+	ip := net.ParseIP(host)
+	if ip == nil {
 		ips, err := net.LookupHost(host)
 		if err != nil || len(ips) == 0 {
-			// If DNS resolution fails, use the hostname as-is
-			ip = host
-		} else {
-			ip = ips[0]
+			return nil, fmt.Errorf("failed to resolve RPC hostname %q: %w", host, err)
 		}
+		ip = net.ParseIP(ips[0])
 	}
 
-	return netAddress{
-		ID:   result.Result.NodeInfo.ID,
-		IP:   ip,
-		Port: port,
-	}, nil
+	addr := p2p.NewNetAddressIPPort(ip, port)
+	addr.ID = p2p.ID(result.Result.NodeInfo.ID)
+	return addr, nil
 }
 
 // parsePortFromListenAddr extracts the port number from a CometBFT listen address
 // like "tcp://0.0.0.0:26656" or "0.0.0.0:26656".
 func parsePortFromListenAddr(listenAddr string) (uint16, error) {
-	// Strip protocol prefix if present
 	addr := listenAddr
 	if idx := strings.Index(addr, "://"); idx >= 0 {
 		addr = addr[idx+3:]

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -70,11 +70,11 @@ func setupStateSync(network, homeDir string) error {
 		return fmt.Errorf("API returned empty state sync peer")
 	}
 
-	return applyStateSync(homeDir, pc.StateSyncRPC, trustHeight, trustHash, stateSyncPeer)
+	return applyStateSync(homeDir, pc.StateSyncRPC, rpcEndpoints[network], trustHeight, trustHash, stateSyncPeer)
 }
 
 // applyStateSync modifies statesync and p2p settings in config.toml.
-func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, stateSyncPeer string) error {
+func applyStateSync(homeDir, providerRPC, officialRPC string, trustHeight int64, trustHash, stateSyncPeer string) error {
 	configPath := filepath.Join(homeDir, "config")
 	configFile := filepath.Join(configPath, "config.toml")
 
@@ -84,7 +84,7 @@ func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, stateSync
 	}
 
 	cfg.StateSync.Enable = true
-	cfg.StateSync.RPCServers = []string{rpc, rpc}
+	cfg.StateSync.RPCServers = []string{providerRPC, officialRPC}
 	cfg.StateSync.TrustHeight = trustHeight
 	cfg.StateSync.TrustHash = trustHash
 

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -1,0 +1,183 @@
+package quickstart
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+type networkConfig struct {
+	GenesisURL   string
+	AddrbookURL  string
+	StateSyncRPC string
+	LivePeersAPI string
+}
+
+var networks = map[string]networkConfig{
+	NetworkMainnet: {
+		GenesisURL:   "https://snapshots.polkachu.com/genesis/initia/genesis.json",
+		AddrbookURL:  "https://snapshots.polkachu.com/addrbook/initia/addrbook.json",
+		StateSyncRPC: "https://initia-rpc.polkachu.com:443",
+		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia/live_peers",
+	},
+	NetworkTestnet: {
+		GenesisURL:   "https://snapshots.polkachu.com/testnet-genesis/initia/genesis.json",
+		AddrbookURL:  "https://snapshots.polkachu.com/testnet-addrbook/initia/addrbook.json",
+		StateSyncRPC: "https://initia-testnet-rpc.polkachu.com:443",
+		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia-testnet/live_peers",
+	},
+}
+
+func downloadGenesis(network, homeDir string) error {
+	nc := networks[network]
+	destPath := filepath.Join(homeDir, "config", "genesis.json")
+	return downloadFile(nc.GenesisURL, destPath)
+}
+
+func downloadAddrbook(network, homeDir string) error {
+	nc := networks[network]
+	destPath := filepath.Join(homeDir, "config", "addrbook.json")
+	return downloadFile(nc.AddrbookURL, destPath)
+}
+
+func downloadFile(url, destPath string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: status %d", url, resp.StatusCode)
+	}
+
+	out, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", destPath, err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+func setupStateSync(network, homeDir string) error {
+	nc := networks[network]
+
+	latestHeight, err := fetchLatestHeight(nc.StateSyncRPC)
+	if err != nil {
+		return fmt.Errorf("failed to fetch latest height: %w", err)
+	}
+
+	trustHeight := latestHeight - 2000
+
+	trustHash, err := fetchBlockHash(nc.StateSyncRPC, trustHeight)
+	if err != nil {
+		return fmt.Errorf("failed to fetch trust hash: %w", err)
+	}
+
+	polkachuPeer, err := fetchPolkachuPeer(nc.LivePeersAPI)
+	if err != nil {
+		return fmt.Errorf("failed to fetch polkachu peer: %w", err)
+	}
+
+	return applyStateSync(homeDir, nc.StateSyncRPC, trustHeight, trustHash, polkachuPeer)
+}
+
+func fetchLatestHeight(rpc string) (int64, error) {
+	resp, err := http.Get(rpc + "/abci_info")
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Result struct {
+			Response struct {
+				LastBlockHeight string `json:"last_block_height"`
+			} `json:"response"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, err
+	}
+
+	var height int64
+	_, err = fmt.Sscanf(result.Result.Response.LastBlockHeight, "%d", &height)
+	return height, err
+}
+
+func fetchBlockHash(rpc string, height int64) (string, error) {
+	url := fmt.Sprintf("%s/block?height=%d", rpc, height)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Result struct {
+			BlockID struct {
+				Hash string `json:"hash"`
+			} `json:"block_id"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.Result.BlockID.Hash, nil
+}
+
+type livePeersResponse struct {
+	PolkachuPeer string `json:"polkachu_peer"`
+}
+
+func fetchPolkachuPeer(apiURL string) (string, error) {
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result livePeersResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.PolkachuPeer, nil
+}
+
+func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, polkachuPeer string) error {
+	configPath := filepath.Join(homeDir, "config", "config.toml")
+
+	vpr := viper.New()
+	vpr.SetConfigFile(configPath)
+	if err := vpr.ReadInConfig(); err != nil {
+		return fmt.Errorf("failed to read config.toml: %w", err)
+	}
+
+	vpr.Set("statesync.enable", true)
+	vpr.Set("statesync.rpc_servers", rpc+","+rpc)
+	vpr.Set("statesync.trust_height", trustHeight)
+	vpr.Set("statesync.trust_hash", trustHash)
+
+	existingPeers := vpr.GetString("p2p.persistent_peers")
+	if !strings.Contains(existingPeers, polkachuPeer) {
+		if existingPeers != "" {
+			existingPeers += ","
+		}
+		existingPeers += polkachuPeer
+		vpr.Set("p2p.persistent_peers", existingPeers)
+	}
+
+	return vpr.WriteConfig()
+}

--- a/cmd/initiad/quickstart/network.go
+++ b/cmd/initiad/quickstart/network.go
@@ -5,107 +5,52 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/p2p/pex"
+
+	"github.com/initia-labs/initia/cmd/initiad/quickstart/providers"
 )
 
-var httpClient = &http.Client{
-	Timeout: 60 * time.Second,
-}
-
-type networkConfig struct {
-	GenesisURL   string
-	AddrbookURL  string
-	StateSyncRPC string
-	LivePeersAPI string
-	RPCURL       string // public RPC endpoint for fallback addrbook generation
-}
-
-var networks = map[string]networkConfig{
-	NetworkMainnet: {
-		GenesisURL:   "https://snapshots.polkachu.com/genesis/initia/genesis.json",
-		AddrbookURL:  "https://snapshots.polkachu.com/addrbook/initia/addrbook.json",
-		StateSyncRPC: "https://initia-rpc.polkachu.com:443",
-		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia/live_peers",
-		RPCURL:       "https://rpc.initia.xyz",
-	},
-	NetworkTestnet: {
-		GenesisURL:   "https://snapshots.polkachu.com/testnet-genesis/initia/genesis.json",
-		AddrbookURL:  "https://snapshots.polkachu.com/testnet-addrbook/initia/addrbook.json",
-		StateSyncRPC: "https://initia-testnet-rpc.polkachu.com:443",
-		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia-testnet/live_peers",
-		RPCURL:       "https://rpc.testnet.initia.xyz",
-	},
+// rpcEndpoints maps network names to public RPC URLs for fallback operations.
+var rpcEndpoints = map[string]string{
+	NetworkMainnet: "https://rpc.initia.xyz",
+	NetworkTestnet: "https://rpc.testnet.initia.xyz",
 }
 
 func downloadGenesis(network, homeDir string) error {
-	nc := networks[network]
+	pc := providers.Polkachu[network]
 	destPath := filepath.Join(homeDir, "config", "genesis.json")
-	return downloadFile(nc.GenesisURL, destPath)
+	return providers.DownloadFile(pc.GenesisURL, destPath)
 }
 
 func downloadAddrbook(network, homeDir string) error {
-	nc := networks[network]
+	pc := providers.Polkachu[network]
 	destPath := filepath.Join(homeDir, "config", "addrbook.json")
-	if err := downloadFile(nc.AddrbookURL, destPath); err != nil {
+	if err := providers.DownloadFile(pc.AddrbookURL, destPath); err != nil {
 		fmt.Printf("Pre-built addrbook download failed (%v), building from RPC peers...\n", err)
-		return buildAddrbookFromRPC(nc.RPCURL, destPath)
+		return buildAddrbookFromRPC(rpcEndpoints[network], destPath)
 	}
 	return nil
 }
 
-func downloadFile(url, destPath string) error {
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return fmt.Errorf("failed to download %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download %s: status %d", url, resp.StatusCode)
-	}
-
-	// Write to temp file and rename atomically to avoid corrupt files on failure
-	tmpPath := destPath + ".tmp"
-	out, err := os.Create(tmpPath)
-	if err != nil {
-		return fmt.Errorf("failed to create %s: %w", tmpPath, err)
-	}
-	defer os.Remove(tmpPath)
-
-	// Limit download to 500MB to prevent disk exhaustion
-	if _, err = io.Copy(out, io.LimitReader(resp.Body, 500<<20)); err != nil {
-		out.Close()
-		return fmt.Errorf("failed to write %s: %w", destPath, err)
-	}
-	if err := out.Close(); err != nil {
-		return fmt.Errorf("failed to close %s: %w", destPath, err)
-	}
-
-	return os.Rename(tmpPath, destPath)
-}
-
 func setupStateSync(network, homeDir string) error {
-	nc := networks[network]
+	pc := providers.Polkachu[network]
 
-	latestHeight, err := fetchLatestHeight(nc.StateSyncRPC)
+	latestHeight, err := providers.FetchLatestHeight(pc.StateSyncRPC)
 	if err != nil {
 		return fmt.Errorf("failed to fetch latest height: %w", err)
 	}
 
 	trustHeight := max(latestHeight-2000, 1)
 
-	trustHash, err := fetchBlockHash(nc.StateSyncRPC, trustHeight)
+	trustHash, err := providers.FetchBlockHash(pc.StateSyncRPC, trustHeight)
 	if err != nil {
 		return fmt.Errorf("failed to fetch trust hash: %w", err)
 	}
@@ -113,7 +58,7 @@ func setupStateSync(network, homeDir string) error {
 		return fmt.Errorf("RPC returned empty block hash for height %d; the block may have been pruned", trustHeight)
 	}
 
-	stateSyncPeer, err := fetchStateSyncPeer(nc.LivePeersAPI)
+	stateSyncPeer, err := providers.FetchStateSyncPeer(pc.LivePeersAPI)
 	if err != nil {
 		return fmt.Errorf("failed to fetch state sync peer: %w", err)
 	}
@@ -121,100 +66,19 @@ func setupStateSync(network, homeDir string) error {
 		return fmt.Errorf("API returned empty state sync peer")
 	}
 
-	return applyStateSync(homeDir, nc.StateSyncRPC, trustHeight, trustHash, stateSyncPeer)
+	return applyStateSync(homeDir, pc.StateSyncRPC, trustHeight, trustHash, stateSyncPeer)
 }
 
-func fetchLatestHeight(rpc string) (int64, error) {
-	resp, err := httpClient.Get(rpc + "/abci_info")
-	if err != nil {
-		return 0, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("RPC %s/abci_info returned status %d", rpc, resp.StatusCode)
-	}
-
-	var result struct {
-		Result struct {
-			Response struct {
-				LastBlockHeight string `json:"last_block_height"`
-			} `json:"response"`
-		} `json:"result"`
-	}
-
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
-		return 0, err
-	}
-
-	var height int64
-	_, err = fmt.Sscanf(result.Result.Response.LastBlockHeight, "%d", &height)
-	return height, err
-}
-
-func fetchBlockHash(rpc string, height int64) (string, error) {
-	url := fmt.Sprintf("%s/block?height=%d", rpc, height)
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("RPC %s returned status %d", url, resp.StatusCode)
-	}
-
-	var result struct {
-		Result struct {
-			BlockID struct {
-				Hash string `json:"hash"`
-			} `json:"block_id"`
-		} `json:"result"`
-	}
-
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
-		return "", err
-	}
-
-	return result.Result.BlockID.Hash, nil
-}
-
-type livePeersResponse struct {
-	StateSyncPeer string `json:"polkachu_peer"`
-}
-
-func fetchStateSyncPeer(apiURL string) (string, error) {
-	resp, err := httpClient.Get(apiURL)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("API %s returned status %d", apiURL, resp.StatusCode)
-	}
-
-	var result livePeersResponse
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
-		return "", err
-	}
-
-	return result.StateSyncPeer, nil
-}
-
-// applyStateSync loads config.toml via viper, modifies statesync/p2p fields,
-// then writes back using CometBFT's WriteConfigFile to preserve comments and formatting.
+// applyStateSync modifies statesync and p2p settings in config.toml.
 func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, stateSyncPeer string) error {
 	configPath := filepath.Join(homeDir, "config")
 	configFile := filepath.Join(configPath, "config.toml")
 
-	// Load config via viper and unmarshal into CometBFT config struct
 	cfg, err := loadCometConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config.toml: %w", err)
 	}
 
-	// Set statesync config
 	cfg.StateSync.Enable = true
 	cfg.StateSync.RPCServers = []string{rpc, rpc}
 	cfg.StateSync.TrustHeight = trustHeight
@@ -228,7 +92,6 @@ func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, stateSync
 		cfg.P2P.PersistentPeers += stateSyncPeer
 	}
 
-	// Write back using CometBFT template to preserve comments
 	cmtcfg.WriteConfigFile(configFile, cfg)
 	return nil
 }
@@ -236,7 +99,6 @@ func applyStateSync(homeDir, rpc string, trustHeight int64, trustHash, stateSync
 // buildAddrbookFromRPC fetches peers from the RPC node's /net_info and builds
 // addrbook.json using CometBFT's pex.AddrBook API.
 func buildAddrbookFromRPC(rpcURL, destPath string) error {
-	// Fetch peer addresses from /net_info
 	peerAddrs, err := fetchNetInfoPeerAddrs(rpcURL)
 	if err != nil {
 		return fmt.Errorf("failed to fetch net_info: %w", err)
@@ -245,19 +107,16 @@ func buildAddrbookFromRPC(rpcURL, destPath string) error {
 		return fmt.Errorf("RPC %s/net_info returned no peers", rpcURL)
 	}
 
-	// Fetch RPC node address for the "src" field
 	srcAddr, err := fetchRPCNodeAddr(rpcURL)
 	if err != nil {
 		return fmt.Errorf("failed to fetch RPC node status: %w", err)
 	}
 
-	// Create addrbook using CometBFT's pex API
 	book := pex.NewAddrBook(destPath, false)
 	book.SetLogger(log.NewNopLogger())
 
 	for _, addr := range peerAddrs {
 		if err := book.AddAddress(addr, srcAddr); err != nil {
-			// Skip peers that fail validation (e.g., non-routable IPs)
 			continue
 		}
 	}
@@ -268,13 +127,13 @@ func buildAddrbookFromRPC(rpcURL, destPath string) error {
 
 // fetchNetInfoPeerAddrs calls /net_info and returns parsed p2p.NetAddress entries.
 func fetchNetInfoPeerAddrs(rpcURL string) ([]*p2p.NetAddress, error) {
-	resp, err := httpClient.Get(rpcURL + "/net_info")
+	resp, err := providers.HTTPClient.Get(rpcURL + "/net_info")
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("%s/net_info returned status %d", rpcURL, resp.StatusCode)
 	}
 
@@ -314,13 +173,13 @@ func fetchNetInfoPeerAddrs(rpcURL string) ([]*p2p.NetAddress, error) {
 // fetchRPCNodeAddr calls /status and resolves the RPC hostname to build
 // the source p2p.NetAddress for addrbook entries.
 func fetchRPCNodeAddr(rpcURL string) (*p2p.NetAddress, error) {
-	resp, err := httpClient.Get(rpcURL + "/status")
+	resp, err := providers.HTTPClient.Get(rpcURL + "/status")
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("%s/status returned status %d", rpcURL, resp.StatusCode)
 	}
 
@@ -333,7 +192,7 @@ func fetchRPCNodeAddr(rpcURL string) (*p2p.NetAddress, error) {
 		} `json:"result"`
 	}
 
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&result); err != nil {
 		return nil, err
 	}
 
@@ -342,7 +201,6 @@ func fetchRPCNodeAddr(rpcURL string) (*p2p.NetAddress, error) {
 		port = 26656
 	}
 
-	// Resolve the RPC URL hostname to get the IP
 	parsed, err := url.Parse(rpcURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse RPC URL %q: %w", rpcURL, err)
@@ -363,8 +221,6 @@ func fetchRPCNodeAddr(rpcURL string) (*p2p.NetAddress, error) {
 	return addr, nil
 }
 
-// parsePortFromListenAddr extracts the port number from a CometBFT listen address
-// like "tcp://0.0.0.0:26656" or "0.0.0.0:26656".
 func parsePortFromListenAddr(listenAddr string) (uint16, error) {
 	addr := listenAddr
 	if idx := strings.Index(addr, "://"); idx >= 0 {
@@ -383,3 +239,4 @@ func parsePortFromListenAddr(listenAddr string) (uint16, error) {
 
 	return uint16(port), nil
 }
+

--- a/cmd/initiad/quickstart/network_test.go
+++ b/cmd/initiad/quickstart/network_test.go
@@ -17,10 +17,10 @@ func TestBuildAddrbookFromRPC(t *testing.T) {
 		switch r.URL.Path {
 		case "/net_info":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":{"peers":[{"node_info":{"id":"abc123def456","listen_addr":"tcp://0.0.0.0:26656"},"remote_ip":"1.2.3.4"},{"node_info":{"id":"def789abc012","listen_addr":"tcp://0.0.0.0:26656"},"remote_ip":"5.6.7.8"}]}}`))
+			_, _ = w.Write([]byte(`{"result":{"peers":[{"node_info":{"id":"abc123def456abc123def456abc123def456abc1","listen_addr":"tcp://0.0.0.0:26656"},"remote_ip":"34.142.172.124"},{"node_info":{"id":"def789abc012def789abc012def789abc012def7","listen_addr":"tcp://0.0.0.0:26656"},"remote_ip":"52.76.41.182"}]}}`))
 		case "/status":
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"result":{"node_info":{"id":"src123node456","listen_addr":"tcp://0.0.0.0:26656"}}}`))
+			_, _ = w.Write([]byte(`{"result":{"node_info":{"id":"src123node456src123node456src123node456src1","listen_addr":"tcp://0.0.0.0:26656"}}}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/cmd/initiad/quickstart/network_test.go
+++ b/cmd/initiad/quickstart/network_test.go
@@ -1,0 +1,85 @@
+package quickstart
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/initia-labs/initia/cmd/initiad/quickstart/providers"
+)
+
+func TestBuildAddrbookFromRPC(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/net_info":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":{"peers":[{"node_info":{"id":"abc123def456","listen_addr":"tcp://0.0.0.0:26656"},"remote_ip":"1.2.3.4"},{"node_info":{"id":"def789abc012","listen_addr":"tcp://0.0.0.0:26656"},"remote_ip":"5.6.7.8"}]}}`))
+		case "/status":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"result":{"node_info":{"id":"src123node456","listen_addr":"tcp://0.0.0.0:26656"}}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	origClient := providers.HTTPClient
+	providers.HTTPClient = srv.Client()
+	defer func() { providers.HTTPClient = origClient }()
+
+	tmpDir := t.TempDir()
+	destPath := filepath.Join(tmpDir, "addrbook.json")
+
+	err := buildAddrbookFromRPC(srv.URL, destPath)
+	require.NoError(t, err)
+
+	info, err := os.Stat(destPath)
+	require.NoError(t, err)
+	require.Greater(t, info.Size(), int64(0), "addrbook.json should be non-empty")
+}
+
+func TestParsePortFromListenAddr(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  uint16
+		expectErr bool
+	}{
+		{
+			name:     "tcp scheme with wildcard host",
+			input:    "tcp://0.0.0.0:26656",
+			expected: 26656,
+		},
+		{
+			name:     "no scheme with wildcard host",
+			input:    "0.0.0.0:26656",
+			expected: 26656,
+		},
+		{
+			name:     "tcp scheme with loopback",
+			input:    "tcp://127.0.0.1:33756",
+			expected: 33756,
+		},
+		{
+			name:      "invalid format",
+			input:     "invalid",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			port, err := parsePortFromListenAddr(tc.input)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, port)
+			}
+		})
+	}
+}

--- a/cmd/initiad/quickstart/providers/polkachu.go
+++ b/cmd/initiad/quickstart/providers/polkachu.go
@@ -1,0 +1,153 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+// HTTPClient is the shared HTTP client with timeout for all provider requests.
+var HTTPClient = &http.Client{
+	Timeout: 60 * time.Second,
+}
+
+// PolkachuConfig holds Polkachu endpoint URLs for a specific network.
+type PolkachuConfig struct {
+	GenesisURL   string
+	AddrbookURL  string
+	StateSyncRPC string
+	LivePeersAPI string
+}
+
+// Polkachu endpoint configurations per network.
+var Polkachu = map[string]PolkachuConfig{
+	"mainnet": {
+		GenesisURL:   "https://snapshots.polkachu.com/genesis/initia/genesis.json",
+		AddrbookURL:  "https://snapshots.polkachu.com/addrbook/initia/addrbook.json",
+		StateSyncRPC: "https://initia-rpc.polkachu.com:443",
+		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia/live_peers",
+	},
+	"testnet": {
+		GenesisURL:   "https://snapshots.polkachu.com/testnet-genesis/initia/genesis.json",
+		AddrbookURL:  "https://snapshots.polkachu.com/testnet-addrbook/initia/addrbook.json",
+		StateSyncRPC: "https://initia-testnet-rpc.polkachu.com:443",
+		LivePeersAPI: "https://polkachu.com/api/v2/chains/initia-testnet/live_peers",
+	},
+}
+
+// FetchStateSyncPeer fetches the state sync peer address from Polkachu's live_peers API.
+func FetchStateSyncPeer(apiURL string) (string, error) {
+	resp, err := HTTPClient.Get(apiURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("API %s returned status %d", apiURL, resp.StatusCode)
+	}
+
+	var result struct {
+		PolkachuPeer string `json:"polkachu_peer"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.PolkachuPeer, nil
+}
+
+// FetchLatestHeight fetches the latest block height from the given RPC endpoint.
+func FetchLatestHeight(rpc string) (int64, error) {
+	resp, err := HTTPClient.Get(rpc + "/abci_info")
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("RPC %s/abci_info returned status %d", rpc, resp.StatusCode)
+	}
+
+	var result struct {
+		Result struct {
+			Response struct {
+				LastBlockHeight string `json:"last_block_height"`
+			} `json:"response"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
+		return 0, err
+	}
+
+	var height int64
+	_, err = fmt.Sscanf(result.Result.Response.LastBlockHeight, "%d", &height)
+	return height, err
+}
+
+// FetchBlockHash fetches the block hash at the given height from the given RPC endpoint.
+func FetchBlockHash(rpc string, height int64) (string, error) {
+	url := fmt.Sprintf("%s/block?height=%d", rpc, height)
+	resp, err := HTTPClient.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("RPC %s returned status %d", url, resp.StatusCode)
+	}
+
+	var result struct {
+		Result struct {
+			BlockID struct {
+				Hash string `json:"hash"`
+			} `json:"block_id"`
+		} `json:"result"`
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.Result.BlockID.Hash, nil
+}
+
+// DownloadFile downloads a URL to destPath atomically (via temp file + rename).
+func DownloadFile(url, destPath string) error {
+	resp, err := HTTPClient.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download %s: status %d", url, resp.StatusCode)
+	}
+
+	return WriteAtomically(destPath, io.LimitReader(resp.Body, 500<<20))
+}
+
+// WriteAtomically writes data from a reader to destPath via a temp file + rename.
+func WriteAtomically(destPath string, r io.Reader) error {
+	tmpPath := destPath + ".tmp"
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", tmpPath, err)
+	}
+	defer os.Remove(tmpPath)
+
+	if _, err = io.Copy(out, r); err != nil {
+		out.Close()
+		return fmt.Errorf("failed to write %s: %w", destPath, err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close %s: %w", destPath, err)
+	}
+
+	return os.Rename(tmpPath, destPath)
+}

--- a/cmd/initiad/quickstart/providers/polkachu.go
+++ b/cmd/initiad/quickstart/providers/polkachu.go
@@ -84,6 +84,10 @@ func FetchLatestHeight(rpc string) (int64, error) {
 		return 0, err
 	}
 
+	if result.Result.Response.LastBlockHeight == "" {
+		return 0, fmt.Errorf("RPC returned empty last_block_height")
+	}
+
 	var height int64
 	_, err = fmt.Sscanf(result.Result.Response.LastBlockHeight, "%d", &height)
 	return height, err

--- a/cmd/initiad/quickstart/providers/polkachu_test.go
+++ b/cmd/initiad/quickstart/providers/polkachu_test.go
@@ -1,0 +1,102 @@
+package providers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchLatestHeight(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/abci_info", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":{"response":{"last_block_height":"12345"}}}`))
+	}))
+	defer srv.Close()
+
+	origClient := HTTPClient
+	HTTPClient = srv.Client()
+	defer func() { HTTPClient = origClient }()
+
+	height, err := FetchLatestHeight(srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, int64(12345), height)
+}
+
+func TestFetchBlockHash(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/block", r.URL.Path)
+		require.Equal(t, "10000", r.URL.Query().Get("height"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":{"block_id":{"hash":"ABCDEF123456"}}}`))
+	}))
+	defer srv.Close()
+
+	origClient := HTTPClient
+	HTTPClient = srv.Client()
+	defer func() { HTTPClient = origClient }()
+
+	hash, err := FetchBlockHash(srv.URL, 10000)
+	require.NoError(t, err)
+	require.Equal(t, "ABCDEF123456", hash)
+}
+
+func TestFetchStateSyncPeer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"polkachu_peer":"abc123@1.2.3.4:26656"}`))
+	}))
+	defer srv.Close()
+
+	origClient := HTTPClient
+	HTTPClient = srv.Client()
+	defer func() { HTTPClient = origClient }()
+
+	peer, err := FetchStateSyncPeer(srv.URL)
+	require.NoError(t, err)
+	require.Equal(t, "abc123@1.2.3.4:26656", peer)
+}
+
+func TestDownloadFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer srv.Close()
+
+	origClient := HTTPClient
+	HTTPClient = srv.Client()
+	defer func() { HTTPClient = origClient }()
+
+	destPath := filepath.Join(t.TempDir(), "downloaded.txt")
+
+	err := DownloadFile(srv.URL+"/file", destPath)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(destPath)
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(data))
+}
+
+func TestDownloadFileAtomicOnFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	origClient := HTTPClient
+	HTTPClient = srv.Client()
+	defer func() { HTTPClient = origClient }()
+
+	destPath := filepath.Join(t.TempDir(), "should_not_exist.txt")
+
+	err := DownloadFile(srv.URL+"/file", destPath)
+	require.Error(t, err)
+
+	_, statErr := os.Stat(destPath)
+	require.True(t, os.IsNotExist(statErr), "dest file should not exist after failed download")
+}

--- a/cmd/initiad/quickstart/snapshot.go
+++ b/cmd/initiad/quickstart/snapshot.go
@@ -23,7 +23,8 @@ func downloadAndExtractSnapshot(snapshotURL, homeDir string) error {
 	}
 
 	// Use separate exec.Command calls to avoid shell injection
-	curl := exec.Command("curl", "-o", "-", "-L", snapshotURL)
+	curl := exec.Command("curl", "-o", "-", "-L", "--progress-bar", snapshotURL)
+	curl.Stderr = os.Stderr // show progress bar
 	lz4 := exec.Command("lz4", "-c", "-d", "-")
 	tar := exec.Command("tar", "-x", "-C", homeDir)
 

--- a/cmd/initiad/quickstart/snapshot.go
+++ b/cmd/initiad/quickstart/snapshot.go
@@ -1,0 +1,28 @@
+package quickstart
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// downloadAndExtractSnapshot downloads a .tar.lz4 snapshot and extracts it to homeDir.
+// Requires `lz4` and `tar` commands to be available in PATH.
+func downloadAndExtractSnapshot(url, homeDir string) error {
+	if _, err := exec.LookPath("lz4"); err != nil {
+		return fmt.Errorf("lz4 command not found. Install it with: apt install lz4 (Linux) or brew install lz4 (macOS)")
+	}
+
+	// Stream download -> lz4 decompress -> tar extract
+	// Equivalent to: curl -o - -L <url> | lz4 -c -d - | tar -x -C <homeDir>
+	cmd := exec.Command("bash", "-c",
+		fmt.Sprintf(`curl -o - -L "%s" | lz4 -c -d - | tar -x -C "%s"`, url, homeDir))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to download and extract snapshot: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/initiad/quickstart/snapshot.go
+++ b/cmd/initiad/quickstart/snapshot.go
@@ -53,9 +53,9 @@ func downloadAndExtractSnapshot(snapshotURL, homeDir string) error {
 	}
 
 	// cleanup
-	defer tar.Cancel()
-	defer lz4.Cancel()
-	defer curl.Cancel()
+	defer tar.Cancel()  //nolint:errcheck
+	defer lz4.Cancel()  //nolint:errcheck
+	defer curl.Cancel() //nolint:errcheck
 
 	// Wait for all processes
 	if err := curl.Wait(); err != nil {

--- a/cmd/initiad/quickstart/snapshot.go
+++ b/cmd/initiad/quickstart/snapshot.go
@@ -2,26 +2,64 @@ package quickstart
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 )
 
 // downloadAndExtractSnapshot downloads a .tar.lz4 snapshot and extracts it to homeDir.
-// Requires `lz4` and `tar` commands to be available in PATH.
-func downloadAndExtractSnapshot(url, homeDir string) error {
-	if _, err := exec.LookPath("lz4"); err != nil {
-		return fmt.Errorf("lz4 command not found. Install it with: apt install lz4 (Linux) or brew install lz4 (macOS)")
+// Requires `curl`, `lz4`, and `tar` commands to be available in PATH.
+func downloadAndExtractSnapshot(snapshotURL, homeDir string) error {
+	// Validate URL to prevent command injection
+	u, err := url.Parse(snapshotURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("invalid snapshot URL: %s (must be http or https)", snapshotURL)
 	}
 
-	// Stream download -> lz4 decompress -> tar extract
-	// Equivalent to: curl -o - -L <url> | lz4 -c -d - | tar -x -C <homeDir>
-	cmd := exec.Command("bash", "-c",
-		fmt.Sprintf(`curl -o - -L "%s" | lz4 -c -d - | tar -x -C "%s"`, url, homeDir))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	for _, tool := range []string{"curl", "lz4", "tar"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			return fmt.Errorf("%s command not found; required for snapshot extraction", tool)
+		}
+	}
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to download and extract snapshot: %w", err)
+	// Use separate exec.Command calls to avoid shell injection
+	curl := exec.Command("curl", "-o", "-", "-L", snapshotURL)
+	lz4 := exec.Command("lz4", "-c", "-d", "-")
+	tar := exec.Command("tar", "-x", "-C", homeDir)
+
+	// Pipe: curl -> lz4 -> tar
+	var err1, err2 error
+	lz4.Stdin, err1 = curl.StdoutPipe()
+	if err1 != nil {
+		return fmt.Errorf("failed to create curl->lz4 pipe: %w", err1)
+	}
+	tar.Stdin, err2 = lz4.StdoutPipe()
+	if err2 != nil {
+		return fmt.Errorf("failed to create lz4->tar pipe: %w", err2)
+	}
+	tar.Stdout = os.Stdout
+	tar.Stderr = os.Stderr
+
+	// Start in reverse order
+	if err := tar.Start(); err != nil {
+		return fmt.Errorf("failed to start tar: %w", err)
+	}
+	if err := lz4.Start(); err != nil {
+		return fmt.Errorf("failed to start lz4: %w", err)
+	}
+	if err := curl.Start(); err != nil {
+		return fmt.Errorf("failed to start curl: %w", err)
+	}
+
+	// Wait for all processes
+	if err := curl.Wait(); err != nil {
+		return fmt.Errorf("curl failed: %w", err)
+	}
+	if err := lz4.Wait(); err != nil {
+		return fmt.Errorf("lz4 failed: %w", err)
+	}
+	if err := tar.Wait(); err != nil {
+		return fmt.Errorf("tar failed: %w", err)
 	}
 
 	return nil

--- a/cmd/initiad/quickstart/snapshot.go
+++ b/cmd/initiad/quickstart/snapshot.go
@@ -52,6 +52,11 @@ func downloadAndExtractSnapshot(snapshotURL, homeDir string) error {
 		return fmt.Errorf("failed to start curl: %w", err)
 	}
 
+	// cleanup
+	defer tar.Cancel()
+	defer lz4.Cancel()
+	defer curl.Cancel()
+
 	// Wait for all processes
 	if err := curl.Wait(); err != nil {
 		return fmt.Errorf("curl failed: %w", err)

--- a/cmd/initiad/quickstart/snapshot_test.go
+++ b/cmd/initiad/quickstart/snapshot_test.go
@@ -1,0 +1,60 @@
+package quickstart
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadAndExtractSnapshot_InvalidURL(t *testing.T) {
+	err := downloadAndExtractSnapshot("not-a-url", "/tmp/fakehome")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid snapshot URL")
+}
+
+func TestDownloadAndExtractSnapshot_FTPScheme(t *testing.T) {
+	err := downloadAndExtractSnapshot("ftp://example.com/file.tar.lz4", "/tmp/fakehome")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http")
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple comma separated",
+			input:    "a,b,c",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "with spaces",
+			input:    " a , b , c ",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "single value",
+			input:    "single",
+			expected: []string{"single"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "empty elements",
+			input:    "a,,b",
+			expected: []string{"a", "b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitAndTrim(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/cmd/initiad/root.go
+++ b/cmd/initiad/root.go
@@ -43,6 +43,7 @@ import (
 	"github.com/initia-labs/initia/app/keepers"
 	"github.com/initia-labs/initia/app/params"
 	initiacmdflags "github.com/initia-labs/initia/cmd/flags"
+	"github.com/initia-labs/initia/cmd/initiad/quickstart"
 	movecmd "github.com/initia-labs/initia/cmd/move"
 	cryptokeyring "github.com/initia-labs/initia/crypto/keyring"
 	"github.com/initia-labs/initia/x/genutil"
@@ -206,6 +207,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig, b
 
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(basicManager, initiaapp.DefaultNodeHome),
+		quickstart.QuickstartCmd(initiaapp.DefaultNodeHome),
 		debug.Cmd(),
 		confixcmd.ConfigCommand(),
 		pruning.Cmd(a.newApp, initiaapp.DefaultNodeHome),

--- a/crypto/ledger/usbwallet/ledger.go
+++ b/crypto/ledger/usbwallet/ledger.go
@@ -288,7 +288,7 @@ func (w *ledgerDriver) ledgerVersion() ([3]byte, error) {
 func (w *ledgerDriver) ledgerDerive(derivationPath []uint32) (common.Address, *ecdsa.PublicKey, error) {
 	// Flatten the derivation path into the Ledger request
 	path := make([]byte, 1+4*len(derivationPath))
-	path[0] = byte(len(derivationPath))
+	path[0] = byte(len(derivationPath)) //nolint:gosec
 	for i, component := range derivationPath {
 		binary.BigEndian.PutUint32(path[1+4*i:], component)
 	}
@@ -360,7 +360,7 @@ func (w *ledgerDriver) ledgerDerive(derivationPath []uint32) (common.Address, *e
 func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction, chainID *big.Int) (common.Address, *types.Transaction, error) {
 	// Flatten the derivation path into the Ledger request
 	path := make([]byte, 1+4*len(derivationPath))
-	path[0] = byte(len(derivationPath))
+	path[0] = byte(len(derivationPath)) //nolint:gosec
 	for i, component := range derivationPath {
 		binary.BigEndian.PutUint32(path[1+4*i:], component)
 	}
@@ -418,7 +418,7 @@ func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction
 		signer = new(types.HomesteadSigner)
 	} else {
 		signer = types.NewEIP155Signer(chainID)
-		signature[64] -= byte(chainID.Uint64()*2 + 35)
+		signature[64] -= byte(chainID.Uint64()*2 + 35) //nolint:gosec
 	}
 	signed, err := tx.WithSignature(signer, signature)
 	if err != nil {
@@ -461,7 +461,7 @@ func (w *ledgerDriver) ledgerSign(derivationPath []uint32, tx *types.Transaction
 func (w *ledgerDriver) ledgerSignTypedMessage(derivationPath []uint32, domainHash []byte, messageHash []byte) ([]byte, error) {
 	// Flatten the derivation path into the Ledger request
 	path := make([]byte, 1+4*len(derivationPath))
-	path[0] = byte(len(derivationPath))
+	path[0] = byte(len(derivationPath)) //nolint:gosec
 	for i, component := range derivationPath {
 		binary.BigEndian.PutUint32(path[1+4*i:], component)
 	}
@@ -523,7 +523,7 @@ func (w *ledgerDriver) ledgerSignTypedMessage(derivationPath []uint32, domainHas
 func (w *ledgerDriver) ledgerSignPersonalMessage(derivationPath []uint32, data []byte) ([]byte, error) {
 	// Flatten the derivation path into the Ledger request
 	path := make([]byte, 1+4*len(derivationPath))
-	path[0] = byte(len(derivationPath))
+	path[0] = byte(len(derivationPath)) //nolint:gosec
 	for i, component := range derivationPath {
 		binary.BigEndian.PutUint32(path[1+4*i:], component)
 	}
@@ -619,8 +619,8 @@ func (w *ledgerDriver) ledgerExchange(opcode ledgerOpcode, p1 ledgerParam1, p2 l
 	// Construct the message payload, possibly split into multiple chunks
 	apdu := make([]byte, 2, 7+len(data))
 
-	binary.BigEndian.PutUint16(apdu, uint16(5+len(data))) //nolint: gosec
-	apdu = append(apdu, []byte{0xe0, byte(opcode), byte(p1), byte(p2), byte(len(data))}...)
+	binary.BigEndian.PutUint16(apdu, uint16(5+len(data)))                                   //nolint:gosec
+	apdu = append(apdu, []byte{0xe0, byte(opcode), byte(p1), byte(p2), byte(len(data))}...) //nolint:gosec
 	apdu = append(apdu, data...)
 
 	// Stream all the chunks to the device
@@ -631,7 +631,7 @@ func (w *ledgerDriver) ledgerExchange(opcode ledgerOpcode, p1 ledgerParam1, p2 l
 	for i := 0; len(apdu) > 0; i++ {
 		// Construct the new message to stream
 		chunk = append(chunk[:0], header...)
-		binary.BigEndian.PutUint16(chunk[3:], uint16(i)) //nolint: gosec
+		binary.BigEndian.PutUint16(chunk[3:], uint16(i))
 
 		if len(apdu) > space {
 			chunk = append(chunk, apdu[:space]...)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -57,7 +57,7 @@ initiad quickstart \
 
 ### Mainnet with Snapshot
 
-Find the latest snapshot URL at https://polkachu.com/tendermint_snapshots/initia
+Find the latest snapshot URL at <https://polkachu.com/tendermint_snapshots/initia>
 
 ```bash
 initiad quickstart \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,149 @@
+# Quickstart Guide
+
+`initiad quickstart` configures your Initia node after running `initiad init`. It downloads the genesis file, address book, and sets up sync method, pruning, indexing, and other settings automatically.
+
+## Prerequisites
+
+```bash
+initiad init <moniker>
+```
+
+## Interactive Mode
+
+The easiest way to set up your node:
+
+```bash
+initiad quickstart --interactive
+```
+
+This walks you through each setting with guided prompts:
+
+1. **Network** - mainnet or testnet
+2. **Sync method** - statesync (fast) or snapshot (requires download URL)
+3. **App state pruning** - default, nothing, everything, or custom
+4. **Block pruning** - minimum blocks to retain (default: 1,000,000)
+5. **TX indexing** - disable, default (IBC-related keys), or custom
+6. **MemIAVL** - enable/disable (not available with snapshot sync)
+7. **REST API** - enable and set listen address
+8. **RPC address** - listen address for RPC server
+
+## Flag Mode
+
+For scripting and automation, pass all options as flags:
+
+### Mainnet with State Sync
+
+```bash
+initiad quickstart \
+  --network=mainnet \
+  --sync-method=statesync \
+  --tx-indexing=default \
+  --pruning=default \
+  --min-retain-blocks=1000000 \
+  --memiavl-enable \
+  --api-address=tcp://0.0.0.0:1317 \
+  --rpc-address=tcp://0.0.0.0:26657
+```
+
+### Testnet with State Sync (Minimal)
+
+```bash
+initiad quickstart \
+  --network=testnet \
+  --sync-method=statesync \
+  --tx-indexing=null \
+  --pruning=everything
+```
+
+### Mainnet with Snapshot
+
+Find the latest snapshot URL at https://polkachu.com/tendermint_snapshots/initia
+
+```bash
+initiad quickstart \
+  --network=mainnet \
+  --sync-method=snapshot \
+  --snapshot-url=https://snapshots.polkachu.com/tendermint_snapshots/initia/initia_12345678.tar.lz4 \
+  --tx-indexing=default \
+  --pruning=default
+```
+
+> Note: Snapshot sync requires `curl`, `lz4`, and `tar` to be installed. MemIAVL cannot be used with snapshot sync.
+
+### Custom Pruning
+
+```bash
+initiad quickstart \
+  --network=mainnet \
+  --sync-method=statesync \
+  --tx-indexing=default \
+  --pruning=custom \
+  --pruning-keep-recent=362880 \
+  --pruning-interval=100
+```
+
+### Custom TX Indexing Keys
+
+```bash
+initiad quickstart \
+  --network=mainnet \
+  --sync-method=statesync \
+  --tx-indexing=custom \
+  --tx-indexing-keys="tx.height,tx.hash,send_packet.packet_sequence" \
+  --pruning=default
+```
+
+## Aliases
+
+`quickstart` can also be invoked as `qstart` or `qs`:
+
+```bash
+initiad qs --interactive
+initiad qstart --network=mainnet --sync-method=statesync --tx-indexing=default --pruning=default
+```
+
+## Flags Reference
+
+| Flag | Description | Values | Default |
+|------|-------------|--------|---------|
+| `--interactive` | Run in interactive mode | - | false |
+| `--network` | Target network | `mainnet`, `testnet` | required |
+| `--sync-method` | How to sync the node | `statesync`, `snapshot` | required |
+| `--snapshot-url` | Snapshot download URL | URL | required for snapshot |
+| `--tx-indexing` | TX indexing mode | `null`, `default`, `custom` | required |
+| `--tx-indexing-keys` | Custom indexing keys | comma-separated | required for custom |
+| `--pruning` | App state pruning | `default`, `nothing`, `everything`, `custom` | required |
+| `--pruning-keep-recent` | States to keep (custom) | integer | - |
+| `--pruning-interval` | Pruning interval (custom) | integer | - |
+| `--min-retain-blocks` | Minimum blocks to retain | integer | 1000000 |
+| `--memiavl-enable` | Enable MemIAVL | - | false |
+| `--api-address` | REST API address (enables API) | `tcp://ip:port` | - |
+| `--rpc-address` | RPC listen address | `tcp://ip:port` | `tcp://127.0.0.1:26657` |
+
+## What It Does
+
+1. **Downloads genesis.json** from Polkachu (with RPC fallback)
+2. **Downloads addrbook.json** from Polkachu (with RPC `/net_info` fallback)
+3. **Configures config.toml** - RPC address, TX indexing, retain height
+4. **Configures app.toml** - pruning, block retention, API, MemIAVL, index events
+5. **Sets up sync method:**
+   - **State sync**: fetches trust height/hash from RPC, configures state sync peer
+   - **Snapshot**: downloads and extracts `.tar.lz4` snapshot
+
+## TX Indexing Presets
+
+- **disable** (`null`): no transaction indexing
+- **default**: IBC-related keys optimized for relayer operations:
+  - `tx.height`, `tx.hash`
+  - `send_packet.packet_sequence`, `recv_packet.packet_sequence`
+  - `write_acknowledgement.packet_sequence`, `acknowledge_packet.packet_sequence`
+  - `timeout_packet.packet_sequence`, `finalize_token_deposit.l1_sequence`
+- **custom**: specify your own comma-separated keys
+
+## After Quickstart
+
+Start your node:
+
+```bash
+initiad start
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -105,7 +105,7 @@ initiad qstart --network=mainnet --sync-method=statesync --tx-indexing=default -
 ## Flags Reference
 
 | Flag | Description | Values | Default |
-|------|-------------|--------|---------|
+| ------ | ------------- | -------- | --------- |
 | `--interactive` | Run in interactive mode | - | false |
 | `--network` | Target network | `mainnet`, `testnet` | required |
 | `--sync-method` | How to sync the node | `statesync`, `snapshot` | required |
@@ -122,7 +122,7 @@ initiad qstart --network=mainnet --sync-method=statesync --tx-indexing=default -
 
 ## What It Does
 
-1. **Downloads genesis.json** from Polkachu (with RPC fallback)
+1. **Downloads genesis.json** from Polkachu (with RPC `/genesis` fallback)
 2. **Downloads addrbook.json** from Polkachu (with RPC `/net_info` fallback)
 3. **Configures config.toml** - RPC address, TX indexing, retain height
 4. **Configures app.toml** - pruning, block retention, API, MemIAVL, index events

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	// we also need to update `LIBMOVEVM_VERSION` of Dockerfile#11
 	github.com/initia-labs/movevm v1.2.0
 	github.com/initia-labs/store v0.1.1
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/noble-assets/forwarding/v2 v2.0.3
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pkg/errors v0.9.1
@@ -66,8 +67,6 @@ require (
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/yaml.v3 v3.0.1
 )
-
-require github.com/mitchellh/mapstructure v1.5.0
 
 require (
 	cloud.google.com/go v0.115.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+require github.com/mitchellh/mapstructure v1.5.0
+
 require (
 	cloud.google.com/go v0.115.1 // indirect
 	cloud.google.com/go/auth v0.9.3 // indirect
@@ -176,7 +178,6 @@ require (
 	github.com/minio/highwayhash v1.0.3 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a // indirect

--- a/integration-tests/e2e/benchmark/load.go
+++ b/integration-tests/e2e/benchmark/load.go
@@ -54,7 +54,7 @@ func BurstLoad(ctx context.Context, cluster *e2e.Cluster, cfg BenchConfig, metas
 				default:
 				}
 
-				seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+				seq := meta.Sequence + uint64(i)
 				viaNode := i % cfg.NodeCount
 				if cfg.ValidatorCount > 0 && cfg.ValidatorCount < cfg.NodeCount {
 					viaNode = edgeNodeIndex(i, cfg.NodeCount, cfg.ValidatorCount)
@@ -125,7 +125,7 @@ func SequentialLoad(ctx context.Context, cluster *e2e.Cluster, cfg BenchConfig, 
 				default:
 				}
 
-				seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+				seq := meta.Sequence + uint64(i)
 				submitTime := time.Now()
 
 				res := cluster.SendBankTxWithSequence(
@@ -253,7 +253,7 @@ func SingleNodeLoad(ctx context.Context, cluster *e2e.Cluster, cfg BenchConfig, 
 				default:
 				}
 
-				seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+				seq := meta.Sequence + uint64(i)
 				submitTime := time.Now()
 
 				res := cluster.SendBankTxWithSequence(
@@ -320,7 +320,7 @@ func MoveExecSequentialLoad(moduleAddr, moduleName, functionName string, typeArg
 					default:
 					}
 
-					seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+					seq := meta.Sequence + uint64(i)
 					submitTime := time.Now()
 
 					res := cluster.SendMoveExecuteJSONWithGas(
@@ -384,7 +384,7 @@ func MoveExecBurstLoad(moduleAddr, moduleName, functionName string, typeArgs, ar
 					default:
 					}
 
-					seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+					seq := meta.Sequence + uint64(i)
 					viaNode := i % cfg.NodeCount
 					if cfg.ValidatorCount > 0 && cfg.ValidatorCount < cfg.NodeCount {
 						viaNode = edgeNodeIndex(i, cfg.NodeCount, cfg.ValidatorCount)
@@ -457,7 +457,7 @@ func QueuedFloodLoad(ctx context.Context, cluster *e2e.Cluster, cfg BenchConfig,
 				default:
 				}
 
-				seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+				seq := meta.Sequence + uint64(i)
 				viaNode := i % cfg.NodeCount
 				if cfg.ValidatorCount > 0 && cfg.ValidatorCount < cfg.NodeCount {
 					viaNode = edgeNodeIndex(i, cfg.NodeCount, cfg.ValidatorCount)
@@ -558,7 +558,7 @@ func QueuedGapLoad(ctx context.Context, cluster *e2e.Cluster, cfg BenchConfig, m
 				default:
 				}
 
-				seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+				seq := meta.Sequence + uint64(i)
 				viaNode := i % cfg.NodeCount
 				if cfg.ValidatorCount > 0 && cfg.ValidatorCount < cfg.NodeCount {
 					viaNode = edgeNodeIndex(i, cfg.NodeCount, cfg.ValidatorCount)
@@ -610,7 +610,7 @@ func PreSignBankTxs(ctx context.Context, t *testing.T, cluster *e2e.Cluster, cfg
 		go func() {
 			defer wg.Done()
 			for i := 0; i < cfg.TxPerAccount; i++ {
-				seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+				seq := meta.Sequence + uint64(i)
 				signed, err := cluster.GenerateSignedBankTx(
 					ctx, name, cluster.ValidatorAddress(), "1uinit",
 					meta.AccountNumber, seq, cfg.GetGasLimit(),
@@ -647,7 +647,7 @@ func PreSignMoveExecTxs(
 		go func() {
 			defer wg.Done()
 			for i := 0; i < cfg.TxPerAccount; i++ {
-				seq := meta.Sequence + uint64(i) //nolint:gosec // i is bounded by TxPerAccount
+				seq := meta.Sequence + uint64(i)
 				signed, err := cluster.GenerateSignedMoveExecTx(
 					ctx, name, moduleAddr, moduleName, functionName,
 					typeArgs, args,
@@ -863,7 +863,7 @@ func sequencePattern(base uint64, count int) []uint64 {
 	}
 
 	for i := 3; i < count; i++ {
-		seqs = append(seqs, base+uint64(i)) //nolint:gosec // i is bounded by count
+		seqs = append(seqs, base+uint64(i))
 	}
 
 	return seqs

--- a/integration-tests/e2e/cluster/cluster.go
+++ b/integration-tests/e2e/cluster/cluster.go
@@ -1391,7 +1391,7 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(dst, bz, 0o600)
+	return os.WriteFile(dst, bz, 0o600) //nolint:gosec
 }
 
 // copyDir copies all files from srcDir into dstDir (non-recursive).

--- a/integration-tests/e2e/cluster/toml.go
+++ b/integration-tests/e2e/cluster/toml.go
@@ -40,5 +40,5 @@ func setTOMLValue(path, section, key, value string) error {
 		return fmt.Errorf("failed to set %s.%s in %s", section, key, path)
 	}
 
-	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600)
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600) //nolint:gosec
 }

--- a/x/distribution/types/dec_pool.go
+++ b/x/distribution/types/dec_pool.go
@@ -241,7 +241,7 @@ func (pools DecPools) String() string {
 
 	var out strings.Builder
 	for _, pool := range pools {
-		out.WriteString(fmt.Sprintf("%v,", pool.String()))
+		fmt.Fprintf(&out, "%v,", pool.String())
 	}
 
 	return strings.TrimSuffix(out.String(), ",")

--- a/x/distribution/types/pool.go
+++ b/x/distribution/types/pool.go
@@ -181,7 +181,7 @@ func (pools Pools) String() string {
 
 	var out strings.Builder
 	for _, pool := range pools {
-		out.WriteString(fmt.Sprintf("%v,", pool.String()))
+		fmt.Fprintf(&out, "%v,", pool.String())
 	}
 
 	return out.String()[:len(out.String())-1]

--- a/x/distribution/types/validator.go
+++ b/x/distribution/types/validator.go
@@ -40,10 +40,10 @@ func (vs ValidatorSlashEvents) String() string {
 	var out strings.Builder
 	out.WriteString("Validator Slash Events:\n")
 	for i, sl := range vs.ValidatorSlashEvents {
-		out.WriteString(fmt.Sprintf(`  Slash %d:
+		fmt.Fprintf(&out, `  Slash %d:
     Period:    %d
     Fractions: %s
-`, i, sl.ValidatorPeriod, sl.Fractions))
+`, i, sl.ValidatorPeriod, sl.Fractions)
 	}
 	return strings.TrimSpace(out.String())
 }

--- a/x/dynamic-fee/keeper/keeper.go
+++ b/x/dynamic-fee/keeper/keeper.go
@@ -126,10 +126,10 @@ func (k Keeper) UpdateBaseGasPrice(ctx sdk.Context) error {
 	}
 
 	// baseFeeMultiplier = (accumulatedGas - targetGas) / targetGas * maxChangeRate + 1
-	baseFeeMultiplier := math.LegacyNewDec(int64(accumulatedGas) - params.TargetGas). //nolint: gosec
-												QuoInt64(params.TargetGas).
-												Mul(params.MaxChangeRate).
-												Add(math.LegacyOneDec())
+	baseFeeMultiplier := math.LegacyNewDec(int64(accumulatedGas) - params.TargetGas).
+		QuoInt64(params.TargetGas).
+		Mul(params.MaxChangeRate).
+		Add(math.LegacyOneDec())
 	newBaseGasPrice := params.BaseGasPrice.Mul(baseFeeMultiplier)
 	if newBaseGasPrice.LT(params.MinBaseGasPrice) {
 		newBaseGasPrice = params.MinBaseGasPrice

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -45,7 +45,7 @@ func (k Keeper) SubmitProposal(ctx context.Context, messages []sdk.Msg, metadata
 	// Loop through all messages and confirm that each has a handler and the gov module account
 	// as the only signer
 	for _, msg := range messages {
-		msgsStr.WriteString(fmt.Sprintf(",%s", sdk.MsgTypeURL(msg)))
+		fmt.Fprintf(&msgsStr, ",%s", sdk.MsgTypeURL(msg))
 
 		// perform a basic validation of the message
 		if m, ok := msg.(sdk.HasValidateBasic); ok {

--- a/x/gov/types/proposal.go
+++ b/x/gov/types/proposal.go
@@ -88,8 +88,8 @@ func (p Proposals) String() string {
 	var out strings.Builder
 	out.WriteString("ID - (Status) [Type] Title\n")
 	for _, prop := range p {
-		out.WriteString(fmt.Sprintf("%d - %s\n",
-			prop.Id, prop.Status))
+		fmt.Fprintf(&out, "%d - %s\n",
+			prop.Id, prop.Status)
 	}
 	return strings.TrimSpace(out.String())
 }

--- a/x/ibc/testing/chain.go
+++ b/x/ibc/testing/chain.go
@@ -113,7 +113,7 @@ func NewTestChainWithValSet(t *testing.T, coord *Coordinator, chainID string, va
 	// generate genesis accounts
 	for i := 0; i < MaxAccounts; i++ {
 		senderPrivKey := secp256k1.GenPrivKey()
-		acc := authtypes.NewBaseAccount(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), uint64(i), 0) //nolint: gosec
+		acc := authtypes.NewBaseAccount(senderPrivKey.PubKey().Address().Bytes(), senderPrivKey.PubKey(), uint64(i), 0)
 		amount, ok := math.NewIntFromString(DefaultGenesisAccBalance)
 		require.True(t, ok)
 

--- a/x/ibc/testing/solomachine.go
+++ b/x/ibc/testing/solomachine.go
@@ -375,7 +375,7 @@ func (solo *Solomachine) SendTransfer(chain *TestChain, portID, channelID string
 		Sender:           chain.SenderAccount.GetAddress().String(),
 		Receiver:         chain.SenderAccount.GetAddress().String(),
 		TimeoutHeight:    clienttypes.ZeroHeight(),
-		TimeoutTimestamp: uint64(chain.GetContext().BlockTime().Add(time.Hour).UnixNano()), //nolint: gosec
+		TimeoutTimestamp: uint64(chain.GetContext().BlockTime().Add(time.Hour).UnixNano()),
 	}
 
 	for _, fn := range fns {

--- a/x/move/types/connector.go
+++ b/x/move/types/connector.go
@@ -614,7 +614,7 @@ func ReadMetadataTableHandleFromMetadataStore(bz []byte) (tableHandle vmtypes.Ac
 
 func ReadUpgradePolicyFromModuleMetadata(bz []byte) (UpgradePolicy, error) {
 	cursor := int(0)
-	upgradePolicy := int8(bz[cursor])
+	upgradePolicy := int8(bz[cursor]) //nolint:gosec
 
 	return UpgradePolicy(upgradePolicy), nil
 }

--- a/x/move/types/env.go
+++ b/x/move/types/env.go
@@ -28,8 +28,8 @@ func NewEnv(ctx context.Context, nextAccountNumber uint64, executionCounter uint
 
 	return vmtypes.Env{
 		ChainId:             sdkCtx.ChainID(),
-		BlockHeight:         uint64(sdkCtx.BlockHeader().Height),          //nolint: gosec
-		BlockTimestampNanos: uint64(sdkCtx.BlockHeader().Time.UnixNano()), //nolint: gosec
+		BlockHeight:         uint64(sdkCtx.BlockHeader().Height), //nolint: gosec
+		BlockTimestampNanos: uint64(sdkCtx.BlockHeader().Time.UnixNano()),
 		NextAccountNumber:   nextAccountNumber,
 		TxHash:              txHash,
 		SessionId:           sessionID,

--- a/x/mstaking/types/delegation.go
+++ b/x/mstaking/types/delegation.go
@@ -185,18 +185,18 @@ func UnmarshalUBD(cdc codec.BinaryCodec, value []byte) (ubd UnbondingDelegation,
 // String returns a human readable string representation of an UnbondingDelegation.
 func (ubd UnbondingDelegation) String() string {
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf(`Unbonding Delegations between:
+	fmt.Fprintf(&out, `Unbonding Delegations between:
   Delegator:                 %s
   Validator:                 %s
-	Entries:`, ubd.DelegatorAddress, ubd.ValidatorAddress))
+	Entries:`, ubd.DelegatorAddress, ubd.ValidatorAddress)
 	for i, entry := range ubd.Entries {
-		out.WriteString(fmt.Sprintf(`    Unbonding Delegation %d:
+		fmt.Fprintf(&out, `    Unbonding Delegation %d:
       Creation Height:           %v
       Min time to unbond (unix): %v
       Expected balance:          %s
 	  Unbonding ID:              %d
       Unbonding Ref Count:       %d`, i, entry.CreationHeight,
-			entry.CompletionTime, entry.Balance, entry.UnbondingId, entry.UnbondingOnHoldRefCount))
+			entry.CompletionTime, entry.Balance, entry.UnbondingId, entry.UnbondingOnHoldRefCount)
 	}
 
 	return out.String()
@@ -290,25 +290,23 @@ func UnmarshalRED(cdc codec.BinaryCodec, value []byte) (red Redelegation, err er
 // String returns a human readable string representation of a Redelegation.
 func (red Redelegation) String() string {
 	var out strings.Builder
-	out.WriteString(fmt.Sprintf(`Redelegations between:
+	fmt.Fprintf(&out, `Redelegations between:
   Delegator:                 %s
   Source Validator:          %s
   Destination Validator:     %s
   Entries:
 `,
-		red.DelegatorAddress, red.ValidatorSrcAddress, red.ValidatorDstAddress,
-	))
+		red.DelegatorAddress, red.ValidatorSrcAddress, red.ValidatorDstAddress)
 
 	for i, entry := range red.Entries {
-		out.WriteString(fmt.Sprintf(`    Redelegation Entry #%d:
+		fmt.Fprintf(&out, `    Redelegation Entry #%d:
     Creation height:           %v
     Min time to unbond (unix): %v
     Dest Shares:               %s
     Unbonding ID:              %d
     Unbonding Ref Count:       %d
 `,
-			i, entry.CreationHeight, entry.CompletionTime, entry.SharesDst, entry.UnbondingId, entry.UnbondingOnHoldRefCount,
-		))
+			i, entry.CreationHeight, entry.CompletionTime, entry.SharesDst, entry.UnbondingId, entry.UnbondingOnHoldRefCount)
 	}
 
 	return strings.TrimRight(out.String(), "\n")


### PR DESCRIPTION
## Summary

- Add `initiad quickstart` (aliases: `qstart`, `qs`) command that configures a node after `initiad init`
- Supports interactive mode (`--interactive`) with guided prompts and flag mode for scripting
- Downloads genesis.json and addrbook.json from Polkachu (with RPC fallback)
- Configures sync method (statesync or snapshot), pruning, TX indexing, MemIAVL, API, and RPC settings
- Uses CometBFT/SDK native config structs to preserve config.toml/app.toml comments and formatting
- Extracts shared config types to `cmd/initiad/appconfig/` package

## New files

```
cmd/initiad/appconfig/appconfig.go          # shared config types
cmd/initiad/quickstart/
├── cmd.go                                  # cobra command, flags, validation
├── config.go                               # config.toml/app.toml modification
├── interactive.go                          # interactive mode prompts
├── network.go                              # genesis/addrbook/statesync orchestration
├── snapshot.go                             # snapshot download + lz4 extraction
└── providers/
    └── polkachu.go                         # Polkachu API/download functions
docs/quickstart.md                          # usage guide
```

## Test plan

- [x] 28 unit tests covering all packages (mock HTTP servers, no real network requests)
- [x] Flag validation tests (valid configs, error cases)
- [x] Config preservation tests (unchanged fields stay intact after quickstart)
- [x] Interactive prompt tests (choice, string, yes/no)
- [x] Addrbook RPC fallback test
- [x] `go test ./cmd/initiad/quickstart/... -count=1` all pass
- [ ] Manual E2E: `initiad init test && initiad quickstart --interactive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)