### PR TITLE
bench: isolate VerifySignature from Sign in benchmark

### DIFF
--- a/crypto/ethsecp256k1/benchmark_test.go
+++ b/crypto/ethsecp256k1/benchmark_test.go
@@ -16,14 +16,14 @@ func BenchmarkPubKey_VerifySignature(b *testing.B) {
 	privKey := GenerateKey()
 	pubKey := privKey.PubKey()
 
+	msg := []byte("benchmark message")
+	sig, err := privKey.Sign(msg)
+	if err != nil {
+	    b.Fatal(err)
+	}
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		msg := fmt.Appendf(nil, "%10d", i)
-		sig, err := privKey.Sign(msg)
-		if err != nil {
-			b.Fatal(err)
-		}
-		pubKey.VerifySignature(msg, sig)
+	    pubKey.VerifySignature(msg, sig)
 	}
 }

--- a/crypto/ethsecp256k1/benchmark_test.go
+++ b/crypto/ethsecp256k1/benchmark_test.go
@@ -19,11 +19,11 @@ func BenchmarkPubKey_VerifySignature(b *testing.B) {
 	msg := []byte("benchmark message")
 	sig, err := privKey.Sign(msg)
 	if err != nil {
-	    b.Fatal(err)
+		b.Fatal(err)
 	}
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-	    pubKey.VerifySignature(msg, sig)
+		pubKey.VerifySignature(msg, sig)
 	}
 }


### PR DESCRIPTION
Move message signing outside the benchmark loop so that BenchmarkPubKey_VerifySignature measures only signature verification, not key signing.