### PR TITLE
fix(abcipp): reject mempool insert no-ops

### DIFF
--- a/abcipp/docs/spec.md
+++ b/abcipp/docs/spec.md
@@ -43,7 +43,7 @@ The `abcipp` package wires up the ABCI++ surfaces that Initia needs: a priority-
 3. **Insert routing**
    * `Insert` infers the tx key from `FirstSignature`, encodes the tx, extracts gas from `FeeTx`, and routes based on nonce vs `nextExpectedNonce()`:
      * `nonce < nextExpected` -> rejected as stale unless it is same-nonce replacement of existing active/queued tx.
-     * `nonce > nextExpected` -> added to the queued pool. When the per-sender limit is hit, the entry with the highest nonce is evicted to prefer lower (closer to promotable) nonces. Same nonce replacement is allowed but requires strictly higher priority; lower-priority candidates are rejected.
+     * `nonce > nextExpected` -> routed to the queued pool. Same-nonce replacement is allowed only when the incoming priority is strictly higher; lower-priority candidates are rejected. When the per-sender limit is hit, a lower-nonce candidate can evict the current highest nonce to prefer closer-to-promotable entries, but a candidate that is itself the highest nonce is rejected. Inserts are also rejected when `MaxQueuedTotal` is already full.
      * `nonce == nextExpected` -> inserted into the priority index. Continuous queued nonce chain is promoted in the same call when capacity permits.
    * For active entries: if a duplicate `(sender, nonce)` already exists, a higher-priority replacement evicts the old entry; lower-priority replacements are rejected.
    * When a tx enters active set (direct insert or queued promotion), clamped ordering fields are computed against sender predecessor/tail so later nonces cannot outrank earlier nonces for the same sender.

--- a/abcipp/docs/spec.md
+++ b/abcipp/docs/spec.md
@@ -43,9 +43,9 @@ The `abcipp` package wires up the ABCI++ surfaces that Initia needs: a priority-
 3. **Insert routing**
    * `Insert` infers the tx key from `FirstSignature`, encodes the tx, extracts gas from `FeeTx`, and routes based on nonce vs `nextExpectedNonce()`:
      * `nonce < nextExpected` -> rejected as stale unless it is same-nonce replacement of existing active/queued tx.
-     * `nonce > nextExpected` -> added to the queued pool. When the per-sender limit is hit, the entry with the highest nonce is evicted to prefer lower (closer to promotable) nonces. Same nonce replacement is allowed but requires strictly higher priority.
+     * `nonce > nextExpected` -> added to the queued pool. When the per-sender limit is hit, the entry with the highest nonce is evicted to prefer lower (closer to promotable) nonces. Same nonce replacement is allowed but requires strictly higher priority; lower-priority candidates are rejected.
      * `nonce == nextExpected` -> inserted into the priority index. Continuous queued nonce chain is promoted in the same call when capacity permits.
-   * For active entries: if a duplicate `(sender, nonce)` already exists, a higher-priority replacement evicts the old entry; lower-priority replacements are ignored.
+   * For active entries: if a duplicate `(sender, nonce)` already exists, a higher-priority replacement evicts the old entry; lower-priority replacements are rejected.
    * When a tx enters active set (direct insert or queued promotion), clamped ordering fields are computed against sender predecessor/tail so later nonces cannot outrank earlier nonces for the same sender.
    * `canAcceptLocked` enforces the `MaxTx` cap by computing an eviction set from the active index and also rejects transactions that exceed consensus block gas/byte limits.
 

--- a/abcipp/mempool_insert.go
+++ b/abcipp/mempool_insert.go
@@ -105,10 +105,13 @@ func (p *PriorityMempool) Insert(ctx context.Context, tx sdk.Tx) error {
 			gas:      gas,
 			bytes:    bz,
 		}
-		inserted, evicted := p.insertQueuedLocked(ss, key, entry)
+		inserted, evicted, insertErr := p.insertQueuedLocked(ss, key, entry)
 		if !inserted {
 			p.mtx.Unlock()
-			return nil
+			if insertErr != nil {
+				return insertErr
+			}
+			return sdkmempool.ErrMempoolTxMaxCapacity
 		}
 		if evicted != nil {
 			p.enqueueEvent(cmtmempool.EventTxRemoved, evicted.bytes)
@@ -137,7 +140,14 @@ func (p *PriorityMempool) Insert(ctx context.Context, tx sdk.Tx) error {
 	if hasExisting {
 		if entry.priority <= existing.priority {
 			p.mtx.Unlock()
-			return nil
+			return errorsmod.Wrapf(
+				sdkerrors.ErrTxInMempoolCache,
+				"active tx with nonce %d for sender %s has priority %d >= replacement priority %d",
+				key.nonce,
+				key.sender,
+				existing.priority,
+				entry.priority,
+			)
 		}
 	}
 	// If a queued tx exists for the same nonce, check priority but defer
@@ -147,7 +157,14 @@ func (p *PriorityMempool) Insert(ctx context.Context, tx sdk.Tx) error {
 	if queued, exists := ss.queued[key.nonce]; exists {
 		if !hasExisting && entry.priority <= queued.priority {
 			p.mtx.Unlock()
-			return nil
+			return errorsmod.Wrapf(
+				sdkerrors.ErrTxInMempoolCache,
+				"queued tx with nonce %d for sender %s has priority %d >= replacement priority %d",
+				key.nonce,
+				key.sender,
+				queued.priority,
+				entry.priority,
+			)
 		}
 		queuedToRemove = queued
 	}
@@ -228,14 +245,21 @@ func (p *PriorityMempool) Insert(ctx context.Context, tx sdk.Tx) error {
 // insertQueuedLocked adds or replaces a tx in the queued pool. When the per sender
 // limit is hit, the entry with the highest nonce is evicted (unless the new tx has
 // the highest nonce, in which case it is rejected). the caller must hold p.mtx.
-func (p *PriorityMempool) insertQueuedLocked(ss *senderState, key txKey, entry *txEntry) (bool, *txEntry) {
+func (p *PriorityMempool) insertQueuedLocked(ss *senderState, key txKey, entry *txEntry) (bool, *txEntry, error) {
 	// same nonce replacement, only if higher priority
 	if existing, exists := ss.queued[key.nonce]; exists {
 		if entry.priority <= existing.priority {
-			return false, nil
+			return false, nil, errorsmod.Wrapf(
+				sdkerrors.ErrTxInMempoolCache,
+				"queued tx with nonce %d for sender %s has priority %d >= replacement priority %d",
+				key.nonce,
+				key.sender,
+				existing.priority,
+				entry.priority,
+			)
 		}
 		ss.queued[key.nonce] = entry
-		return true, existing
+		return true, existing, nil
 	}
 
 	// per sender eviction, swap highest nonce for a lower one
@@ -248,21 +272,21 @@ func (p *PriorityMempool) insertQueuedLocked(ss *senderState, key txKey, entry *
 			}
 		}
 		if key.nonce >= highestNonce {
-			return false, nil
+			return false, nil, sdkmempool.ErrMempoolTxMaxCapacity
 		}
 		evicted = ss.queued[highestNonce]
 		delete(ss.queued, highestNonce)
 		p.queuedCount.Add(-1)
 		ss.setQueuedRangeOnRemoveLocked(highestNonce)
 	} else if p.maxQueuedTotal > 0 && int(p.queuedCount.Load()) >= p.maxQueuedTotal {
-		return false, nil
+		return false, nil, sdkmempool.ErrMempoolTxMaxCapacity
 	}
 
 	ss.queued[key.nonce] = entry
 	p.queuedCount.Add(1)
 	ss.setQueuedRangeOnInsertLocked(key.nonce)
 
-	return true, evicted
+	return true, evicted, nil
 }
 
 // collectPromotableLocked removes queued txs with continuous nonces starting from

--- a/abcipp/mempool_remove.go
+++ b/abcipp/mempool_remove.go
@@ -173,7 +173,7 @@ func (p *PriorityMempool) demoteActiveRangeLocked(
 		}
 
 		entry.tier = queuedTier
-		inserted, evicted := p.insertQueuedLocked(ss, entry.key, entry)
+		inserted, evicted, _ := p.insertQueuedLocked(ss, entry.key, entry)
 		if evicted != nil {
 			removed = append(removed, evicted)
 		}

--- a/abcipp/mempool_test.go
+++ b/abcipp/mempool_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	sdkmempool "github.com/cosmos/cosmos-sdk/types/mempool"
 )
 
 // newTestMempoolWithEvents builds a mempool with event channel wiring so each
@@ -247,9 +249,10 @@ func TestQueuedPerSenderCapEvictsHighestNonce(t *testing.T) {
 	require.False(t, ok4)
 }
 
-// TestQueuedTotalCapSilentlyRejectsFutureNonce verifies global queued
-// limit behavior: inserts beyond global queued capacity are skipped without error.
-func TestQueuedTotalCapSilentlyRejectsFutureNonce(t *testing.T) {
+// TestQueuedTotalCapRejectsFutureNonce verifies global queued limit behavior:
+// inserts beyond global queued capacity are rejected so ProxyMempool does not
+// cache txs that the app-side mempool did not accept.
+func TestQueuedTotalCapRejectsFutureNonce(t *testing.T) {
 	keeper := newMockAccountKeeper()
 	mp := NewPriorityMempool(PriorityMempoolConfig{
 		MaxTx:          64,
@@ -280,12 +283,34 @@ func TestQueuedTotalCapSilentlyRejectsFutureNonce(t *testing.T) {
 	require.NoError(t, mp.Insert(ctx, newTestTxWithPriv(privB, 2, 1000, "default")))
 	drainEvents(eventCh)
 
-	// This queued insert should be silently skipped because total queued is full.
-	require.NoError(t, mp.Insert(ctx, newTestTxWithPriv(privC, 2, 1000, "default")))
+	// This queued insert should be rejected because total queued is full.
+	require.ErrorIs(t, mp.Insert(ctx, newTestTxWithPriv(privC, 2, 1000, "default")), sdkmempool.ErrMempoolTxMaxCapacity)
 	ins, rem := collectEvents(eventCh)
 	require.Len(t, ins, 0)
 	require.Len(t, rem, 0)
 	require.Equal(t, 5, mp.CountTx(), "3 active + 2 queued expected")
+}
+
+func TestLowerPriorityReplacementRejected(t *testing.T) {
+	mp, keeper, sdkCtx, eventCh := newTestMempoolWithEvents(t, 32)
+
+	priv := secp256k1.GenPrivKey()
+	sender := sdk.AccAddress(priv.PubKey().Address())
+	keeper.SetSequence(sender, 0)
+
+	txHigh := newTestTxWithPriv(priv, 0, 1000, "default")
+	require.NoError(t, mp.Insert(sdk.WrapSDKContext(sdkCtx.WithPriority(100)), txHigh))
+	drainEvents(eventCh)
+
+	txLow := newTestTxWithPriv(priv, 0, 1000, "default")
+	err := mp.Insert(sdk.WrapSDKContext(sdkCtx.WithPriority(10)), txLow)
+	require.ErrorIs(t, err, sdkerrors.ErrTxInMempoolCache)
+
+	ins, rem := collectEvents(eventCh)
+	require.Len(t, ins, 0)
+	require.Len(t, rem, 0)
+	require.True(t, mp.Contains(txHigh))
+	require.Equal(t, 1, mp.CountTx())
 }
 
 // TestPromotionCapacityFailureRequeuesChain verifies promotion under capacity

--- a/abcipp/mempool_test.go
+++ b/abcipp/mempool_test.go
@@ -313,6 +313,97 @@ func TestLowerPriorityReplacementRejected(t *testing.T) {
 	require.Equal(t, 1, mp.CountTx())
 }
 
+// TestQueuedLowerPriorityReplacementRejected verifies that a same-nonce queued
+// replacement with insufficient priority is rejected with ErrTxInMempoolCache
+// so ProxyMempool does not cache a tx the app-side mempool did not accept.
+func TestQueuedLowerPriorityReplacementRejected(t *testing.T) {
+	mp, keeper, sdkCtx, eventCh := newTestMempoolWithEvents(t, 32)
+
+	priv := secp256k1.GenPrivKey()
+	sender := sdk.AccAddress(priv.PubKey().Address())
+	keeper.SetSequence(sender, 0)
+
+	require.NoError(t, mp.Insert(sdk.WrapSDKContext(sdkCtx.WithPriority(50)), newTestTxWithPriv(priv, 0, 1000, "default")))
+	txHigh := newTestTxWithPriv(priv, 2, 1000, "default")
+	require.NoError(t, mp.Insert(sdk.WrapSDKContext(sdkCtx.WithPriority(100)), txHigh))
+	drainEvents(eventCh)
+
+	txLow := newTestTxWithPriv(priv, 2, 1000, "default")
+	err := mp.Insert(sdk.WrapSDKContext(sdkCtx.WithPriority(10)), txLow)
+	require.ErrorIs(t, err, sdkerrors.ErrTxInMempoolCache)
+
+	ins, rem := collectEvents(eventCh)
+	require.Len(t, ins, 0)
+	require.Len(t, rem, 0)
+	require.True(t, mp.Contains(txHigh))
+	require.Equal(t, 2, mp.CountTx(), "1 active + 1 queued, rejected replacement must not change counts")
+}
+
+// TestQueuedSameNonceAsNextExpectedLowerPriorityRejected covers the Insert main
+// body path where a queued tx exists for key.nonce == nextExpected and the new
+// insert has insufficient priority. This path must also reject instead of
+// silently returning nil.
+func TestQueuedSameNonceAsNextExpectedLowerPriorityRejected(t *testing.T) {
+	mp, keeper, sdkCtx, eventCh := newTestMempoolWithEvents(t, 32)
+
+	priv := secp256k1.GenPrivKey()
+	sender := sdk.AccAddress(priv.PubKey().Address())
+	keeper.SetSequence(sender, 0)
+
+	// Put a higher-priority tx in the queued pool at nonce 1 (since nextExpected=0).
+	txQueuedHigh := newTestTxWithPriv(priv, 1, 1000, "default")
+	require.NoError(t, mp.Insert(sdk.WrapSDKContext(sdkCtx.WithPriority(100)), txQueuedHigh))
+
+	// Advance the sender cursor so nextExpected becomes 1, placing queued[1] at
+	// exactly nonce == nextExpected. This drives the next Insert through the
+	// main-body queued-collision branch rather than insertQueuedLocked.
+	mp.mtx.Lock()
+	ss := mp.senders[sender.String()]
+	ss.setOnChainSeqLocked(1)
+	mp.mtx.Unlock()
+	drainEvents(eventCh)
+
+	txLow := newTestTxWithPriv(priv, 1, 1000, "default")
+	err := mp.Insert(sdk.WrapSDKContext(sdkCtx.WithPriority(10)), txLow)
+	require.ErrorIs(t, err, sdkerrors.ErrTxInMempoolCache)
+
+	ins, rem := collectEvents(eventCh)
+	require.Len(t, ins, 0)
+	require.Len(t, rem, 0)
+	require.Equal(t, 1, mp.CountTx(), "queued entry must remain untouched")
+}
+
+// TestQueuedPerSenderCapRejectsHighestNonce verifies the per-sender cap edge
+// case: when the sender's queued pool is full and the new nonce is >= current
+// highest nonce, the insert is rejected with ErrMempoolTxMaxCapacity instead
+// of silently returning nil.
+func TestQueuedPerSenderCapRejectsHighestNonce(t *testing.T) {
+	mp, keeper, sdkCtx, eventCh := newTestMempoolWithEvents(t, 64)
+	mp.SetMaxQueuedPerSender(2)
+	ctx := sdk.WrapSDKContext(sdkCtx)
+
+	priv := secp256k1.GenPrivKey()
+	sender := sdk.AccAddress(priv.PubKey().Address())
+	keeper.SetSequence(sender, 0)
+
+	require.NoError(t, mp.Insert(ctx, newTestTxWithPriv(priv, 0, 1000, "default")))
+	require.NoError(t, mp.Insert(ctx, newTestTxWithPriv(priv, 2, 1000, "default")))
+	require.NoError(t, mp.Insert(ctx, newTestTxWithPriv(priv, 3, 1000, "default")))
+	drainEvents(eventCh)
+
+	// nonce=5 is higher than current highest queued nonce=3, must be rejected.
+	err := mp.Insert(ctx, newTestTxWithPriv(priv, 5, 1000, "default"))
+	require.ErrorIs(t, err, sdkmempool.ErrMempoolTxMaxCapacity)
+
+	ins, rem := collectEvents(eventCh)
+	require.Len(t, ins, 0)
+	require.Len(t, rem, 0)
+	require.Equal(t, 3, mp.CountTx(), "1 active + 2 queued, rejected tx must not change counts")
+
+	_, ok5 := mp.Lookup(sender.String(), 5)
+	require.False(t, ok5)
+}
+
 // TestPromotionCapacityFailureRequeuesChain verifies promotion under capacity
 // pressure promotes what fits and requeues the remaining suffix without loss.
 func TestPromotionCapacityFailureRequeuesChain(t *testing.T) {


### PR DESCRIPTION
# Description

Closes: N/A

This PR makes `PriorityMempool.Insert` return an error when a tx is not actually accepted into the app-side mempool. Previously, some no-op reject paths returned `nil`, which let `BaseApp.CheckTx` report success. CometBFT `ProxyMempool` then cached those txs in `knownTxs` even though Initia's app-side mempool did not contain them, leaving no later app-side remove event to clear the CometBFT cache.

The changed paths are:

- lower-priority active or queued same-nonce replacements now return `ErrTxInMempoolCache`
- queued capacity rejects now return `ErrMempoolTxMaxCapacity`
- docs now describe these candidates as rejected rather than ignored

---

## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
  <!-- * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit -->
- [x] confirmed `!` in the type prefix if API or client breaking change: not applicable
- [x] targeted the correct branch: `main`
- [x] provided a link to the relevant issue or specification: not applicable
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] confirmed all CI checks have passed: pending draft PR CI

## Validation

```text
go test ./abcipp -count=1
```

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage