### PR TITLE
!fix(move): respect script disabled for json scripts

### DIFF
--- a/x/move/keeper/msg_server.go
+++ b/x/move/keeper/msg_server.go
@@ -177,9 +177,14 @@ func (ms MsgServer) Script(ctx context.Context, req *types.MsgScript) (*types.Ms
 }
 
 // ScriptJSON implements script execution
-func (ms MsgServer) ScriptJSON(context context.Context, req *types.MsgScriptJSON) (*types.MsgScriptJSONResponse, error) {
+func (ms MsgServer) ScriptJSON(ctx context.Context, req *types.MsgScriptJSON) (*types.MsgScriptJSONResponse, error) {
+	if ok, err := ms.ScriptEnabled(ctx); err != nil {
+		return nil, err
+	} else if !ok {
+		return nil, errors.Wrap(types.ErrScriptDisabled, "script execution is disabled")
+	}
+
 	defer telemetry.MeasureSince(time.Now(), "move", "msg", "script_json")
-	ctx := sdk.UnwrapSDKContext(context)
 	if err := req.Validate(ms.ac); err != nil {
 		return nil, err
 	}

--- a/x/move/keeper/msg_server_test.go
+++ b/x/move/keeper/msg_server_test.go
@@ -79,6 +79,9 @@ func Test_ScriptDisabled(t *testing.T) {
 	msgServer := keeper.NewMsgServerImpl(&input.MoveKeeper)
 	_, err = msgServer.Script(ctx, nil)
 	require.ErrorIs(t, err, types.ErrScriptDisabled)
+
+	_, err = msgServer.ScriptJSON(ctx, nil)
+	require.ErrorIs(t, err, types.ErrScriptDisabled)
 }
 
 func Test_ExecuteMsg(t *testing.T) {


### PR DESCRIPTION
# Description

Closes: N/A

This PR makes `MsgServer.ScriptJSON` respect the move module `ScriptEnabled` parameter before validating or executing a JSON script message. This matches the existing `Script` behavior and prevents JSON script execution when script execution has been disabled by params.

The change also extends the existing disabled-script keeper test to assert that `ScriptJSON` returns `types.ErrScriptDisabled`.

This is not a breaking change.

---

## Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title, you can find examples of the prefixes below:
- [x] confirmed `!` in the type prefix if API or client breaking change: not applicable, this is not breaking
- [x] targeted the correct branch: `main`
- [x] provided a link to the relevant issue or specification: not applicable
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc): not applicable
- [ ] confirmed all CI checks have passed: pending CI

## Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage

## Validation

- `go test ./x/move/keeper -run Test_ScriptDisabled -count=1`