### PR TITLE
fix(dynamic-fee): reject zero target gas

### DIFF
--- a/x/dynamic-fee/types/params.go
+++ b/x/dynamic-fee/types/params.go
@@ -51,8 +51,8 @@ func (p Params) Validate() error {
 		return fmt.Errorf("max base gas price must be non-negative")
 	}
 
-	if p.TargetGas < 0 {
-		return fmt.Errorf("target gas must be non-negative")
+	if p.TargetGas <= 0 {
+		return fmt.Errorf("target gas must be positive")
 	}
 
 	if p.BaseGasPrice.LT(p.MinBaseGasPrice) {

--- a/x/dynamic-fee/types/params_test.go
+++ b/x/dynamic-fee/types/params_test.go
@@ -1,0 +1,20 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/initia-labs/initia/x/dynamic-fee/types"
+)
+
+func TestParamsValidateTargetGas(t *testing.T) {
+	params := types.DefaultParams()
+	require.NoError(t, params.Validate())
+
+	params.TargetGas = 0
+	require.ErrorContains(t, params.Validate(), "target gas must be positive")
+
+	params.TargetGas = -1
+	require.ErrorContains(t, params.Validate(), "target gas must be positive")
+}


### PR DESCRIPTION
# Description

Closes: 0xWeb3boy/Initia-Move-Bug#3

Reject zero `TargetGas` values in dynamic-fee params validation. `UpdateBaseGasPrice` cannot compute a multiplier with `TargetGas == 0`, so the params validator now requires a positive value before genesis or governance parameter updates can persist it.

This is a defensive validation hardening change. The parameter is authority-controlled, but invalid values should still be rejected at the params boundary.

Validation:

- `go test ./x/dynamic-fee/types -run TestParamsValidateTargetGas -count=1`
- `go test ./x/dynamic-fee/... -count=1`

Breaking change: no.

---

## Author Checklist

I have...

- [x] included the correct type prefix in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change: not applicable
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary: not applicable
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for documenting Go code: not applicable
- [ ] confirmed all CI checks have passed

## Reviewers Checklist

I have...

- [ ] confirmed the correct type prefix in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
