### PR TITLE
fix(mstaking): detect zero-token exchange rates

### DIFF
--- a/x/mstaking/types/validator.go
+++ b/x/mstaking/types/validator.go
@@ -277,8 +277,8 @@ func (v Validator) SetInitialCommission(commission Commission) (Validator, error
 // Validator loses all tokens due to slashing. In this case,
 // make all future delegations invalid.
 func (v Validator) InvalidExRate() bool {
-	for _, token := range v.Tokens {
-		if token.IsZero() && v.DelegatorShares.AmountOf(token.Denom).IsPositive() {
+	for _, share := range v.DelegatorShares {
+		if share.Amount.IsPositive() && v.Tokens.AmountOf(share.Denom).IsZero() {
 			return true
 		}
 	}

--- a/x/mstaking/types/validator_test.go
+++ b/x/mstaking/types/validator_test.go
@@ -104,6 +104,15 @@ func TestShareTokens(t *testing.T) {
 	assert.Equal(t, decCoins(5), validator.TokensFromShares(sdk.NewDecCoins(sdk.NewDecCoin(sdk.DefaultBondDenom, math.NewInt(10)))))
 }
 
+func TestInvalidExRate(t *testing.T) {
+	validator := mkValidator(coins(100), decCoins(100))
+	require.False(t, validator.InvalidExRate())
+
+	validator = validator.RemoveTokens(coins(100))
+	require.True(t, validator.Tokens.IsZero())
+	require.True(t, validator.InvalidExRate())
+}
+
 func TestRemoveTokens(t *testing.T) {
 	validator := mkValidator(coins(100), decCoins(100))
 


### PR DESCRIPTION
# Description

Closes: 0xWeb3boy/Initia-Move-Bug#1

Update `Validator.InvalidExRate()` to detect the zero-token exchange-rate state by iterating delegator shares instead of validator tokens. `sdk.Coins` drops zero-amount denoms, so a fully removed token balance is represented by an absent denom rather than a `0` coin entry.

This keeps the guard aligned with the condition it is meant to catch: positive outstanding shares for a denom whose validator token balance is zero.

Validation:

- `go test ./x/mstaking/types -run TestInvalidExRate -count=1`
- `go test ./x/mstaking/types -count=1`

Breaking change: no.

---

## Author Checklist

I have...

- [x] included the correct type prefix in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change: not applicable
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary: not applicable
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification, including comments for documenting Go code: not applicable
- [ ] confirmed all CI checks have passed

## Reviewers Checklist

I have...

- [ ] confirmed the correct type prefix in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
