### PR TITLE
fix(nft-transfer): decode refund packets consistently

### DIFF
--- a/x/ibc/nft-transfer/ibc_module.go
+++ b/x/ibc/nft-transfer/ibc_module.go
@@ -224,8 +224,8 @@ func (im IBCModule) OnAcknowledgementPacket(
 	if err := im.keeper.Codec().UnmarshalJSON(acknowledgement, &ack); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal ICS-721 nft-transfer packet acknowledgement: %v", err)
 	}
-	var data types.NonFungibleTokenPacketData
-	if err := im.keeper.Codec().UnmarshalJSON(packet.GetData(), &data); err != nil {
+	data, err := types.DecodePacketData(packet.GetData())
+	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal ICS-721 nft-transfer packet data: %s", err.Error())
 	}
 
@@ -273,8 +273,8 @@ func (im IBCModule) OnTimeoutPacket(
 	packet channeltypes.Packet,
 	relayer sdk.AccAddress,
 ) error {
-	var data types.NonFungibleTokenPacketData
-	if err := im.keeper.Codec().UnmarshalJSON(packet.GetData(), &data); err != nil {
+	data, err := types.DecodePacketData(packet.GetData())
+	if err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal ICS-721 nft-transfer packet data: %s", err.Error())
 	}
 	// refund tokens

--- a/x/ibc/nft-transfer/keeper/relay_test.go
+++ b/x/ibc/nft-transfer/keeper/relay_test.go
@@ -169,6 +169,75 @@ func (suite *KeeperTestSuite) TestOnTimeoutPacket() {
 	suite.Require().Equal(sender, owner)
 }
 
+func (suite *KeeperTestSuite) TestOnTimeoutPacketSinkZoneRefundPadsOmittedTokenUris() {
+	suite.SetupTest()
+
+	classUri := "uri"
+	className := "name"
+	classSymbol := "symbol"
+	nftId := "kitty"
+	nftUri := ""
+	nftData := ""
+
+	pathA2B := NewTransferPath(suite.chainA, suite.chainB)
+	suite.coordinator.SetupConnections(pathA2B)
+	suite.coordinator.CreateChannels(pathA2B)
+
+	senderA := pathA2B.EndpointA.Chain.SenderAccount.GetAddress()
+	receiverB := pathA2B.EndpointB.Chain.SenderAccount.GetAddress()
+	moveKeeperB := pathA2B.EndpointB.Chain.GetInitiaApp().MoveKeeper
+	nftKeeperB := movekeeper.NewNftKeeper(moveKeeperB)
+
+	classId := suite.CreateNftClass(pathA2B.EndpointA, className, classUri, classSymbol)
+	suite.MintNft(pathA2B.EndpointA, senderA, classId, className, nftId, nftUri, nftData)
+
+	packet := suite.transferNft(
+		pathA2B.EndpointA,
+		pathA2B.EndpointB,
+		classId,
+		nftId,
+		senderA.String(),
+		receiverB.String(),
+	)
+
+	voucherClassId := suite.receiverNft(pathA2B.EndpointA, pathA2B.EndpointB, packet)
+	suite.ConfirmClassId(pathA2B.EndpointB, classId, voucherClassId)
+
+	returnPacket := suite.transferNft(
+		pathA2B.EndpointB,
+		pathA2B.EndpointA,
+		voucherClassId,
+		nftId,
+		receiverB.String(),
+		senderA.String(),
+	)
+
+	var rawData types.NonFungibleTokenPacketData
+	err := suite.chainB.Codec.UnmarshalJSON(returnPacket.GetData(), &rawData)
+	suite.Require().NoError(err)
+	suite.Require().Len(rawData.TokenIds, 1)
+	suite.Require().Empty(rawData.TokenUris)
+
+	for uint64(suite.chainA.GetContext().BlockHeight()) <= returnPacket.TimeoutHeight.RevisionHeight {
+		suite.coordinator.CommitBlock(suite.chainA)
+	}
+	suite.Require().NoError(pathA2B.EndpointB.UpdateClient())
+
+	err = pathA2B.EndpointB.TimeoutPacket(returnPacket)
+	suite.Require().NoError(err)
+
+	owner := suite.GetNFTOwner(
+		pathA2B.EndpointB.Chain.GetContext(),
+		pathA2B.EndpointB.Chain.GetInitiaApp().NftTransferKeeper,
+		moveKeeperB,
+		&nftKeeperB,
+		voucherClassId,
+		voucherClassId,
+		nftId,
+	)
+	suite.Require().Equal(receiverB, owner)
+}
+
 func (suite *KeeperTestSuite) TestClassIdPathFromHash() {
 	ctx, k := suite.SetupKeeperTest()
 


### PR DESCRIPTION
# Description

Closes: N/A

This PR updates the NFT transfer refund handlers to decode packet data with the same `types.DecodePacketData` helper used by the receive path.

The refund paths previously raw-decoded packet data in `OnAcknowledgementPacket` and `OnTimeoutPacket`. Packet serialization can omit all-empty `token_uris` and `token_data` fields, while `DecodePacketData` restores those slices to match `token_ids`. Using the raw decode left sink-zone refund data with mismatched slice lengths, which could make voucher re-minting fail during timeout or error-ack refund processing.

This also adds a keeper-level regression test that exercises the sink-zone timeout refund path with omitted token URIs and verifies the voucher is re-minted to the sender.

---

## Author Checklist

I have...

- [x] included the correct type prefix in the PR title
- [x] confirmed `!` in the type prefix is not applicable because this is not a breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification: N/A
- [x] reviewed "Files changed" and left comments if necessary
- [x] included the necessary unit and integration tests
- [x] updated the relevant documentation or specification: N/A
- [ ] confirmed all CI checks have passed

## Validation

- `go test ./x/ibc/nft-transfer/...`
- `make format`
